### PR TITLE
Fix bug -- return null when `getValueType()` is called at first.

### DIFF
--- a/src/Scanner/PropertyScanner.php
+++ b/src/Scanner/PropertyScanner.php
@@ -141,6 +141,7 @@ class PropertyScanner implements ScannerInterface
      */
     public function getValueType()
     {
+        $this->scan();
         return $this->valueType;
     }
 

--- a/test/Scanner/PropertyScannerTest.php
+++ b/test/Scanner/PropertyScannerTest.php
@@ -100,4 +100,30 @@ CLASS;
             }
         }
     }
+
+    /**
+     * @group issue-8
+     */
+    public function testPropertyScannerReturnsProperValueRegardlessOfOrder()
+    {
+        $class = <<<'CLASS'
+<?php
+class Foo
+{
+    private $string = 'string';
+    private $int = 123;
+}
+CLASS;
+
+        $tokenScanner = new TokenArrayScanner(token_get_all($class));
+        $class = $tokenScanner->getClass('Foo');
+
+        $property = $class->getProperty('string');
+        $this->assertEquals('string', $property->getValue());
+        $this->assertEquals('string', $property->getValueType());
+
+        $property = $class->getProperty('int');
+        $this->assertEquals('int', $property->getValueType());
+        $this->assertEquals(123, $property->getValue());
+    }
 }


### PR DESCRIPTION
Example:

```php
<?php

$source = <<<'EOS'
<?php
class Pizza
{
    public $price = 100;
}
EOS;

$scanner = new Zend\Code\Scanner\TokenArrayScanner(token_get_all($source));
$class   = $scanner->getClass('Pizza');
$price   = $class->getProperty('price');

var_dump($price->getValueType()); // => NULL
```

If other method was called at first:

```php
$scanner = new Zend\Code\Scanner\TokenArrayScanner(token_get_all($source));
$class   = $scanner->getClass('Pizza');
$price   = $class->getProperty('price');

var_dump($price->getValue());     // => string(3) "100"
var_dump($price->getValueType()); // => string(3) "int"
```