### PR TITLE
Added the creation of array with short syntax

### DIFF
--- a/src/Generator/ValueGenerator.php
+++ b/src/Generator/ValueGenerator.php
@@ -356,7 +356,15 @@ class ValueGenerator extends AbstractGenerator
             case self::TYPE_ARRAY:
             case self::TYPE_ARRAY_LONG:
             case self::TYPE_ARRAY_SHORT:
-                $output .= ($type == self::TYPE_ARRAY_SHORT) ? '[' : 'array(';
+                if ($type == self::TYPE_ARRAY_SHORT) {
+                    $startArray = '[';
+                    $endArray   = ']';
+                } else {
+                    $startArray = 'array(';
+                    $endArray = ')';
+                }
+
+                $output .= $startArray;
                 if ($this->outputMode == self::OUTPUT_MULTIPLE_LINE) {
                     $output .= self::LINE_FEED . str_repeat($this->indentation, $this->arrayDepth + 1);
                 }
@@ -392,7 +400,7 @@ class ValueGenerator extends AbstractGenerator
                     }
                     $output .= self::LINE_FEED . str_repeat($this->indentation, $this->arrayDepth);
                 }
-                $output .= ($type == self::TYPE_ARRAY_SHORT) ? ']' : ')';
+                $output .= $endArray;
                 break;
             case self::TYPE_OTHER:
             default:

--- a/src/Generator/ValueGenerator.php
+++ b/src/Generator/ValueGenerator.php
@@ -16,20 +16,22 @@ class ValueGenerator extends AbstractGenerator
     /**#@+
      * Constant values
      */
-    const TYPE_AUTO     = 'auto';
-    const TYPE_BOOLEAN  = 'boolean';
-    const TYPE_BOOL     = 'bool';
-    const TYPE_NUMBER   = 'number';
-    const TYPE_INTEGER  = 'integer';
-    const TYPE_INT      = 'int';
-    const TYPE_FLOAT    = 'float';
-    const TYPE_DOUBLE   = 'double';
-    const TYPE_STRING   = 'string';
-    const TYPE_ARRAY    = 'array';
-    const TYPE_CONSTANT = 'constant';
-    const TYPE_NULL     = 'null';
-    const TYPE_OBJECT   = 'object';
-    const TYPE_OTHER    = 'other';
+    const TYPE_AUTO        = 'auto';
+    const TYPE_BOOLEAN     = 'boolean';
+    const TYPE_BOOL        = 'bool';
+    const TYPE_NUMBER      = 'number';
+    const TYPE_INTEGER     = 'integer';
+    const TYPE_INT         = 'int';
+    const TYPE_FLOAT       = 'float';
+    const TYPE_DOUBLE      = 'double';
+    const TYPE_STRING      = 'string';
+    const TYPE_ARRAY       = 'array';
+    const TYPE_ARRAY_SHORT = 'array_short';
+    const TYPE_ARRAY_LONG  = 'array_long';
+    const TYPE_CONSTANT    = 'constant';
+    const TYPE_NULL        = 'null';
+    const TYPE_OBJECT      = 'object';
+    const TYPE_OTHER       = 'other';
     /**#@-*/
 
     const OUTPUT_MULTIPLE_LINE = 'multipleLine';
@@ -249,6 +251,8 @@ class ValueGenerator extends AbstractGenerator
             self::TYPE_DOUBLE,
             self::TYPE_STRING,
             self::TYPE_ARRAY,
+            self::TYPE_ARRAY_SHORT,
+            self::TYPE_ARRAY_LONG,
             self::TYPE_CONSTANT,
             self::TYPE_NULL,
             self::TYPE_OBJECT,
@@ -312,12 +316,19 @@ class ValueGenerator extends AbstractGenerator
             $type = $this->getAutoDeterminedType($value);
         }
 
-        if ($type == self::TYPE_ARRAY) {
+        if (in_array($type, array(self::TYPE_ARRAY, self::TYPE_ARRAY_LONG, self::TYPE_ARRAY_SHORT))) {
             foreach ($value as &$curValue) {
                 if ($curValue instanceof self) {
                     continue;
                 }
-                $curValue = new self($curValue, self::TYPE_AUTO, self::OUTPUT_MULTIPLE_LINE, $this->getConstants());
+
+                if (is_array($curValue) && $type == self::TYPE_ARRAY_SHORT) {
+                    $newType = self::TYPE_ARRAY_SHORT;
+                } else {
+                    $newType = self::TYPE_AUTO;
+                }
+
+                $curValue = new self($curValue, $newType, self::OUTPUT_MULTIPLE_LINE, $this->getConstants());
             }
         }
 
@@ -343,7 +354,9 @@ class ValueGenerator extends AbstractGenerator
                 $output .= $value;
                 break;
             case self::TYPE_ARRAY:
-                $output .= 'array(';
+            case self::TYPE_ARRAY_LONG:
+            case self::TYPE_ARRAY_SHORT:
+                $output .= ($type == self::TYPE_ARRAY_SHORT) ? '[' : 'array(';
                 if ($this->outputMode == self::OUTPUT_MULTIPLE_LINE) {
                     $output .= self::LINE_FEED . str_repeat($this->indentation, $this->arrayDepth + 1);
                 }
@@ -379,7 +392,7 @@ class ValueGenerator extends AbstractGenerator
                     }
                     $output .= self::LINE_FEED . str_repeat($this->indentation, $this->arrayDepth);
                 }
-                $output .= ')';
+                $output .= ($type == self::TYPE_ARRAY_SHORT) ? ']' : ')';
                 break;
             case self::TYPE_OTHER:
             default:

--- a/src/Generator/ValueGenerator.php
+++ b/src/Generator/ValueGenerator.php
@@ -316,14 +316,16 @@ class ValueGenerator extends AbstractGenerator
             $type = $this->getAutoDeterminedType($value);
         }
 
-        if (in_array($type, array(self::TYPE_ARRAY, self::TYPE_ARRAY_LONG, self::TYPE_ARRAY_SHORT))) {
+        $isArrayType = in_array($type, [self::TYPE_ARRAY, self::TYPE_ARRAY_LONG, self::TYPE_ARRAY_SHORT]);
+
+        if ($isArrayType) {
             foreach ($value as &$curValue) {
                 if ($curValue instanceof self) {
                     continue;
                 }
 
-                if (is_array($curValue) && $type == self::TYPE_ARRAY_SHORT) {
-                    $newType = self::TYPE_ARRAY_SHORT;
+                if (is_array($curValue)) {
+                    $newType = $type;
                 } else {
                     $newType = self::TYPE_AUTO;
                 }

--- a/test/Generator/ValueGeneratorTest.php
+++ b/test/Generator/ValueGeneratorTest.php
@@ -25,8 +25,8 @@ class ValueGeneratorTest extends \PHPUnit_Framework_TestCase
     protected function generateArrayData($longOutput, $value)
     {
         $shortOutput = str_replace(
-            array('array(', ')'),
-            array('[', ']'),
+            ['array(', ')'],
+            ['[', ']'],
             $longOutput
         );
 

--- a/test/Generator/ValueGeneratorTest.php
+++ b/test/Generator/ValueGeneratorTest.php
@@ -45,6 +45,7 @@ class ValueGeneratorTest extends \PHPUnit_Framework_TestCase
             ],
         ];
     }
+
     /**
      * Data provider for testPropertyDefaultValueCanHandleArray test
      *
@@ -235,5 +236,4 @@ EOS;
             ["\\'", "\\\\\\'"],
         ];
     }
-
 }

--- a/test/Generator/ValueGeneratorTest.php
+++ b/test/Generator/ValueGeneratorTest.php
@@ -20,9 +20,6 @@ use Zend\Code\Generator\ValueGenerator;
 class ValueGeneratorTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @param $longOutput
-     * @param $value
-     *
      * @return array
      */
     protected function generateArrayData($longOutput, $value)
@@ -144,10 +141,6 @@ EOS;
 
     /**
      * @dataProvider unsortedKeysArrayProvider
-     *
-     * @param string $type
-     * @param array $value
-     * @param string $expected
      */
     public function testPropertyDefaultValueCanHandleArrayWithUnsortedKeys($type, $value, $expected)
     {
@@ -180,10 +173,6 @@ EOS;
 
     /**
      * @dataProvider simpleArrayProvider
-     *
-     * @param string $type
-     * @param array $value
-     * @param string $expected
      */
     public function testPropertyDefaultValueCanHandleArray($type, $value, $expected)
     {
@@ -212,10 +201,6 @@ EOS;
 
     /**
      * @dataProvider complexArrayProvider
-     *
-     * @param string $type
-     * @param array $value
-     * @param string $expected
      */
     public function testPropertyDefaultValueCanHandleComplexArrayOfTypes($type, $value, $expected)
     {

--- a/test/Generator/ValueGeneratorTest.php
+++ b/test/Generator/ValueGeneratorTest.php
@@ -36,7 +36,7 @@ class ValueGeneratorTest extends \PHPUnit_Framework_TestCase
     {
         $valueGenerator = new ValueGenerator();
         $valueGenerator->setValue('foo');
-        $this->assertEquals('\'foo\'', $valueGenerator->generate());
+        $this->assertEquals("'foo'", $valueGenerator->generate());
     }
 
     public function testPropertyDefaultValueCanHandleArray()
@@ -88,7 +88,7 @@ EOS;
             5,
             'one' => 1,
             'two' => '2',
-            'constant1' => '__DIR__ . \'/anydir1/anydir2\'',
+            'constant1' => "__DIR__ . '/anydir1/anydir2'",
             [
                 'baz' => true,
                 'foo',
@@ -135,7 +135,7 @@ EOS;
             5,
             'one' => 1,
             'two' => '2',
-            'constant1' => '__DIR__ . \'/anydir1/anydir2\'',
+            'constant1' => "__DIR__ . '/anydir1/anydir2'",
             [
                 'baz' => true,
                 'foo',

--- a/test/Generator/ValueGeneratorTest.php
+++ b/test/Generator/ValueGeneratorTest.php
@@ -52,6 +52,20 @@ EOS;
         $this->assertEquals($expectedSource, $valueGenerator->generate());
     }
 
+    public function testPropertyDefaultValueCanHandleShortArray()
+    {
+        $expectedSource = <<<EOS
+[
+    'foo',
+]
+EOS;
+
+        $valueGenerator = new ValueGenerator();
+        $valueGenerator->setValue(['foo']);
+        $valueGenerator->setType(ValueGenerator::TYPE_ARRAY_SHORT);
+        $this->assertEquals($expectedSource, $valueGenerator->generate());
+    }
+
     public function testPropertyDefaultValueCanHandleUnquotedString()
     {
         $valueGenerator = new ValueGenerator();
@@ -115,6 +129,54 @@ EOS;
         $this->assertEquals($expectedSource, $generatedTargetSource);
     }
 
+    public function testPropertyDefaultValueCanHandleComplexShortArrayOfTypes()
+    {
+        $targetValue = [
+            5,
+            'one' => 1,
+            'two' => '2',
+            'constant1' => '__DIR__ . \'/anydir1/anydir2\'',
+            [
+                'baz' => true,
+                'foo',
+                'bar',
+                [
+                    'baz1',
+                    'baz2',
+                    'constant2' => 'ArrayObject::STD_PROP_LIST',
+                ]
+            ],
+            new ValueGenerator('PHP_EOL', 'constant')
+        ];
+
+        $expectedSource = <<<EOS
+[
+    5,
+    'one' => 1,
+    'two' => '2',
+    'constant1' => __DIR__ . '/anydir1/anydir2',
+    [
+        'baz' => true,
+        'foo',
+        'bar',
+        [
+            'baz1',
+            'baz2',
+            'constant2' => ArrayObject::STD_PROP_LIST,
+        ],
+    ],
+    PHP_EOL,
+]
+EOS;
+
+        $valueGenerator = new ValueGenerator();
+        $valueGenerator->initEnvironmentConstants();
+        $valueGenerator->setValue($targetValue);
+        $valueGenerator->setType(ValueGenerator::TYPE_ARRAY_SHORT);
+        $generatedTargetSource = $valueGenerator->generate();
+        $this->assertEquals($expectedSource, $generatedTargetSource);
+    }
+
     public function testPropertyDefaultValueCanHandleArrayWithUnsortedKeys()
     {
         $value = [
@@ -135,6 +197,32 @@ array(
     7 => 'd',
     3 => 'e',
 )
+EOS;
+
+        $this->assertEquals($expectedSource, $valueGenerator->generate());
+    }
+
+    public function testPropertyDefaultValueCanHandleShortArrayWithUnsortedKeys()
+    {
+        $value = [
+            1 => 'a',
+            0 => 'b',
+            'c',
+            7 => 'd',
+            3 => 'e'
+        ];
+
+        $valueGenerator = new ValueGenerator();
+        $valueGenerator->setValue($value);
+        $valueGenerator->setType(ValueGenerator::TYPE_ARRAY_SHORT);
+        $expectedSource = <<<EOS
+[
+    1 => 'a',
+    0 => 'b',
+    'c',
+    7 => 'd',
+    3 => 'e',
+]
 EOS;
 
         $this->assertEquals($expectedSource, $valueGenerator->generate());


### PR DESCRIPTION
Added the creation of shorty syntax arrays.

This is the new behaviour:

```
$expectedSource = <<<EOS
[
    'foo',
]
EOS;

$valueGenerator = new ValueGenerator();
$valueGenerator->setValue(['foo']);
$valueGenerator->setType(ValueGenerator::TYPE_ARRAY_SHORT);

var_dump($expectedSource === $valueGenerator->generate()); /// Outputs true
```

The old behaviour still works as expected and is the default behaviour:

```
$expectedSource = <<<EOS
array(
    'foo',
)
EOS;

$valueGenerator = new ValueGenerator();
$valueGenerator->setValue(['foo']);

var_dump($expectedSource === $valueGenerator->generate()); /// Outputs true
```

Should fix issue #9 