### PR TITLE
Require zend-stdlib

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,7 @@
         "phpunit/PHPUnit": "~4.0"
     },
     "suggest": {
-        "doctrine/common": "Doctrine\\Common >=2.1 for annotation features",
-        "zendframework/zend-stdlib": "Zend\\Stdlib component"
+        "doctrine/common": "Doctrine\\Common >=2.1 for annotation features"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/src/Generator/ValueGenerator.php
+++ b/src/Generator/ValueGenerator.php
@@ -9,7 +9,7 @@
 
 namespace Zend\Code\Generator;
 
-use Zend\Stdlib\ArrayObject;
+use ArrayObject;
 
 class ValueGenerator extends AbstractGenerator
 {


### PR DESCRIPTION
zend-eventmanager used to "require" zend-stdlib but in 3.0 (branch develop) this is gone (zend-stdlib is moved from require to require-dev).

This means that zend-stdlib was always installed when zend-code was.
But by allowing eventmanager ^3.0, this is not true anymore, and breaks packages that relied on this assumption (see e.g. #21 and https://github.com/Ocramius/ProxyManager/issues/260)