### PR TITLE
Make Stdlib's ArrayObject a soft dependency of ValueGenerator

### DIFF
--- a/src/Generator/ValueGenerator.php
+++ b/src/Generator/ValueGenerator.php
@@ -9,7 +9,9 @@
 
 namespace Zend\Code\Generator;
 
-use Zend\Stdlib\ArrayObject;
+use ArrayObject as SplArrayObject;
+use Zend\Code\Exception\InvalidArgumentException;
+use Zend\Stdlib\ArrayObject as StdlibArrayObject;
 
 class ValueGenerator extends AbstractGenerator
 {
@@ -61,17 +63,17 @@ class ValueGenerator extends AbstractGenerator
     protected $allowedTypes = null;
     /**
      * Autodetectable constants
-     * @var ArrayObject
+     * @var SplArrayObject|StdlibArrayObject
      */
-    protected $constants = null;
+    protected $constants;
 
     /**
      * @param mixed       $value
      * @param string      $type
      * @param string      $outputMode
-     * @param ArrayObject $constants
+     * @param null|SplArrayObject|StdlibArrayObject $constants
      */
-    public function __construct($value = null, $type = self::TYPE_AUTO, $outputMode = self::OUTPUT_MULTIPLE_LINE, ArrayObject $constants = null)
+    public function __construct($value = null, $type = self::TYPE_AUTO, $outputMode = self::OUTPUT_MULTIPLE_LINE, $constants = null)
     {
         // strict check is important here if $type = AUTO
         if ($value !== null) {
@@ -83,11 +85,14 @@ class ValueGenerator extends AbstractGenerator
         if ($outputMode !== self::OUTPUT_MULTIPLE_LINE) {
             $this->setOutputMode($outputMode);
         }
-        if ($constants !== null) {
-            $this->constants = $constants;
-        } else {
-            $this->constants = new ArrayObject();
+        if ($constants === null) {
+            $constants = new SplArrayObject();
+        } elseif (!(($constants instanceof SplArrayObject) || ($constants instanceof StdlibArrayObject))) {
+            throw new InvalidArgumentException(
+                '$constants must be an instance of ArrayObject or Zend\Stdlib\ArrayObject'
+            );
         }
+        $this->constants = $constants;
     }
 
     /**
@@ -143,7 +148,7 @@ class ValueGenerator extends AbstractGenerator
     /**
      * Return constant list
      *
-     * @return ArrayObject
+     * @return SplArrayObject|StdlibArrayObject
      */
     public function getConstants()
     {

--- a/src/Generator/ValueGenerator.php
+++ b/src/Generator/ValueGenerator.php
@@ -9,6 +9,7 @@
 
 namespace Zend\Code\Generator;
 
+use ArrayAccess;
 use ArrayObject as SplArrayObject;
 use Zend\Code\Exception\InvalidArgumentException;
 use Zend\Stdlib\ArrayObject as StdlibArrayObject;
@@ -73,7 +74,7 @@ class ValueGenerator extends AbstractGenerator
      * @param string      $outputMode
      * @param null|SplArrayObject|StdlibArrayObject $constants
      */
-    public function __construct($value = null, $type = self::TYPE_AUTO, $outputMode = self::OUTPUT_MULTIPLE_LINE, $constants = null)
+    public function __construct($value = null, $type = self::TYPE_AUTO, $outputMode = self::OUTPUT_MULTIPLE_LINE, ArrayAccess $constants = null)
     {
         // strict check is important here if $type = AUTO
         if ($value !== null) {

--- a/src/Generator/ValueGenerator.php
+++ b/src/Generator/ValueGenerator.php
@@ -9,7 +9,6 @@
 
 namespace Zend\Code\Generator;
 
-use ArrayAccess;
 use ArrayObject as SplArrayObject;
 use Zend\Code\Exception\InvalidArgumentException;
 use Zend\Stdlib\ArrayObject as StdlibArrayObject;
@@ -74,7 +73,7 @@ class ValueGenerator extends AbstractGenerator
      * @param string      $outputMode
      * @param null|SplArrayObject|StdlibArrayObject $constants
      */
-    public function __construct($value = null, $type = self::TYPE_AUTO, $outputMode = self::OUTPUT_MULTIPLE_LINE, ArrayAccess $constants = null)
+    public function __construct($value = null, $type = self::TYPE_AUTO, $outputMode = self::OUTPUT_MULTIPLE_LINE, $constants = null)
     {
         // strict check is important here if $type = AUTO
         if ($value !== null) {

--- a/test/Generator/ValueGeneratorTest.php
+++ b/test/Generator/ValueGeneratorTest.php
@@ -9,6 +9,10 @@
 
 namespace ZendTest\Code\Generator;
 
+use ArrayAccess;
+use ArrayObject as SplArrayObject;
+use Zend\Code\Exception\InvalidArgumentException;
+use Zend\Stdlib\ArrayObject as StdlibArrayObject;
 use Zend\Code\Generator\ValueGenerator;
 
 /**
@@ -19,10 +23,40 @@ use Zend\Code\Generator\ValueGenerator;
  */
 class ValueGeneratorTest extends \PHPUnit_Framework_TestCase
 {
-    public function testPropertyDefaultValueConstructor()
+    public function testDefaultInstance()
     {
         $valueGenerator = new ValueGenerator();
-        $this->isInstanceOf($valueGenerator, 'Zend\Code\Generator\ValueGenerator');
+
+        $this->assertInstanceOf(SplArrayObject::class, $valueGenerator->getConstants());
+    }
+
+    public function testInvalidConstantsType()
+    {
+        $this->setExpectedException(
+            InvalidArgumentException::class,
+            '$constants must be an instance of ArrayObject or Zend\Stdlib\ArrayObject'
+        );
+
+        $constants = $this->getMock(ArrayAccess::class);
+        new ValueGenerator(null, ValueGenerator::TYPE_AUTO, ValueGenerator::OUTPUT_MULTIPLE_LINE, $constants);
+    }
+
+    /**
+     * @dataProvider constantsTypeProvider
+     */
+    public function testAllowedPossibleConstantsType($constants)
+    {
+        $valueGenerator = new ValueGenerator(null, ValueGenerator::TYPE_AUTO, ValueGenerator::OUTPUT_MULTIPLE_LINE, $constants);
+
+        $this->assertSame($constants, $valueGenerator->getConstants());
+    }
+
+    public function constantsTypeProvider()
+    {
+        return [
+            SplArrayObject::class => [new SplArrayObject()],
+            StdlibArrayObject::class => [new StdlibArrayObject()],
+        ];
     }
 
     public function testPropertyDefaultValueIsSettable()


### PR DESCRIPTION
Alternative to  #22.

Note: PropertyReflection require stdlib PriorityQueue due the EventManager use.

Close: #22
Fix: #21
