### PR TITLE
Use a bound constraint and right package for the doctrine annotations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,13 +17,13 @@
         "zendframework/zend-eventmanager": "^2.6|^3.0"
     },
     "require-dev": {
-        "doctrine/common": ">=2.1",
+        "doctrine/annotations": "~1.0",
         "zendframework/zend-stdlib": "~2.7",
         "fabpot/php-cs-fixer": "1.7.*",
         "phpunit/PHPUnit": "~4.0"
     },
     "suggest": {
-        "doctrine/common": "Doctrine\\Common >=2.1 for annotation features",
+        "doctrine/annotations": "Doctrine\\Common\\Annotations >=1.0 for annotation features",
         "zendframework/zend-stdlib": "Zend\\Stdlib component"
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
Installing the full doctrine/common package is not necessary when only doctrine/annotations is used