### PR TITLE
WIP[3.0] Pull logic out of TraitUsageGenerator and into ImportGenerator

### DIFF
--- a/src/Generator/ClassGenerator.php
+++ b/src/Generator/ClassGenerator.php
@@ -668,11 +668,7 @@ class ClassGenerator extends AbstractGenerator
      */
     public function addUse($use, $useAlias = null)
     {
-        if (! empty($useAlias)) {
-            $use .= ' as ' . $useAlias;
-        }
-
-        $this->uses[$use] = $use;
+        $this->uses[$use] = $useAlias;
         return $this;
     }
 
@@ -683,7 +679,12 @@ class ClassGenerator extends AbstractGenerator
      */
     public function getUses()
     {
-        return array_values($this->uses);
+        $uses = [];
+        foreach ($this->uses as $use => $useAlias) {
+            $uses[] = ! empty($useAlias) ? $use . ' as ' . $useAlias : $use;
+        };
+
+        return $uses;
     }
 
     /**

--- a/src/Generator/ClassGenerator.php
+++ b/src/Generator/ClassGenerator.php
@@ -688,6 +688,53 @@ class ClassGenerator extends AbstractGenerator
     }
 
     /**
+     * @param string $use
+     * @return bool
+     */
+    public function hasUse($use)
+    {
+        return array_key_exists($use, $this->uses);
+    }
+
+    /**
+     * @param  string $methodName
+     * @return ClassGenerator
+     */
+    public function removeUse($use)
+    {
+        if ($this->hasUse($use)) {
+            unset($this->uses[$use]);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param string $use
+     * @return bool
+     */
+    public function hasUseAlias($use)
+    {
+        if ($this->hasUse($use)) {
+            return !empty($this->uses[$use]);
+        }
+
+        return false;
+    }
+
+    /**
+     * @param $use
+     * @return ClassGenerator
+     */
+    public function removeUseAlias($use)
+    {
+        if ($this->hasUse($use)) {
+            $this->addUse($use);
+        }
+        return $this;
+    }
+
+    /**
      * @param  string $propertyName
      * @return bool
      */

--- a/src/Generator/ClassGenerator.php
+++ b/src/Generator/ClassGenerator.php
@@ -30,6 +30,11 @@ class ClassGenerator extends AbstractGenerator
     protected $namespaceName = null;
 
     /**
+     * @var array Array of string names
+     */
+    protected $uses = [];
+
+    /**
      * @var DocBlockGenerator
      */
     protected $docBlock = null;
@@ -663,7 +668,11 @@ class ClassGenerator extends AbstractGenerator
      */
     public function addUse($use, $useAlias = null)
     {
-        $this->traitUsageGenerator->addUse($use, $useAlias);
+        if (! empty($useAlias)) {
+            $use .= ' as ' . $useAlias;
+        }
+
+        $this->uses[$use] = $use;
         return $this;
     }
 
@@ -674,7 +683,7 @@ class ClassGenerator extends AbstractGenerator
      */
     public function getUses()
     {
-        return $this->traitUsageGenerator->getUses();
+        return array_values($this->uses);
     }
 
     /**

--- a/src/Generator/TraitUsageGenerator.php
+++ b/src/Generator/TraitUsageGenerator.php
@@ -33,35 +33,9 @@ class TraitUsageGenerator extends AbstractGenerator
      */
     protected $traitOverrides = [];
 
-    /**
-     * @var array Array of string names
-     */
-    protected $uses = [];
-
     public function __construct(ClassGenerator $classGenerator)
     {
         $this->classGenerator = $classGenerator;
-    }
-
-    /**
-     * @inherit Zend\Code\Generator\TraitUsageInterface
-     */
-    public function addUse($use, $useAlias = null)
-    {
-        if (! empty($useAlias)) {
-            $use .= ' as ' . $useAlias;
-        }
-
-        $this->uses[$use] = $use;
-        return $this;
-    }
-
-    /**
-     * @inherit Zend\Code\Generator\TraitUsageInterface
-     */
-    public function getUses()
-    {
-        return array_values($this->uses);
     }
 
     /**

--- a/test/Generator/ClassGeneratorTest.php
+++ b/test/Generator/ClassGeneratorTest.php
@@ -421,6 +421,48 @@ CODE;
         $this->assertContains('use My\First\Use\Class as MyAlias;', $generated);
     }
 
+    public function testHasUse()
+    {
+        $classGenerator = new ClassGenerator();
+        $classGenerator->addUse('My\First\Use\Class');
+        $classGenerator->addUse('My\Second\Use\Class', 'MyAlias');
+
+        $this->assertTrue($classGenerator->hasUse('My\First\Use\Class'));
+        $this->assertTrue($classGenerator->hasUse('My\Second\Use\Class'));
+    }
+
+    public function testRemoveUse()
+    {
+        $classGenerator = new ClassGenerator();
+        $classGenerator->addUse('My\First\Use\Class');
+        $classGenerator->addUse('My\Second\Use\Class', 'MyAlias');
+
+        $this->assertTrue($classGenerator->hasUse('My\First\Use\Class'));
+        $this->assertTrue($classGenerator->hasUse('My\Second\Use\Class'));
+        $classGenerator->removeUse('My\First\Use\Class');
+        $classGenerator->removeUse('My\Second\Use\Class');
+        $this->assertFalse($classGenerator->hasUse('My\First\Use\Class'));
+        $this->assertFalse($classGenerator->hasUse('My\Second\Use\Class'));
+    }
+
+    public function testHasUseAlias()
+    {
+        $classGenerator = new ClassGenerator();
+        $classGenerator->addUse('My\First\Use\Class');
+        $classGenerator->addUse('My\Second\Use\Class', 'MyAlias');
+        $this->assertFalse($classGenerator->hasUseAlias('My\First\Use\Class'));
+        $this->assertTrue($classGenerator->hasUseAlias('My\Second\Use\Class'));
+    }
+
+    public function testRemoveUseAlias()
+    {
+        $classGenerator = new ClassGenerator();
+        $classGenerator->addUse('My\First\Use\Class', 'MyAlias');
+        $this->assertTrue($classGenerator->hasUseAlias('My\First\Use\Class'));
+        $classGenerator->removeUseAlias('My\First\Use\Class');
+        $this->assertFalse($classGenerator->hasUseAlias('My\First\Use\Class'));
+    }
+
     public function testCreateFromArrayWithDocBlockFromArray()
     {
         $classGenerator = ClassGenerator::fromArray([


### PR DESCRIPTION
- [x] not the responsibility of TraitUsageGenerator.
- [x] Additionally since i want to add has- and remove methods (see #26) I think the alias logic has to be rewritten. It is currently stored in an array where the key equals its value. It's sibling method 'getUses' simply returns array_values for that. I don't see any reason for this state keeping.
  What would be a good way to properly store use and aliases such that I can add hasUse($use), hasUseAlias($use, $alias) removeUse($use) and removeUseAlias($use, $alias)?
