### PR TITLE
Allow to define if the type is an alias or not.

### DIFF
--- a/src/Generator/ParameterGenerator.php
+++ b/src/Generator/ParameterGenerator.php
@@ -163,14 +163,20 @@ class ParameterGenerator extends AbstractGenerator
     }
 
     /**
-     * @param  string $type
+     * @param  mixed $type
      * @return ParameterGenerator
      */
     public function setType($type)
     {
-        $this->type = TypeGenerator::fromTypeString($type);
+        if (is_array($type)) {
+            $this->type = TypeGenerator::fromTypeArray($type);
+            return $this;
+        }
 
-        return $this;
+        if (is_string($type)) {
+            $this->type = TypeGenerator::fromTypeString($type);
+            return $this;
+        }
     }
 
     /**

--- a/src/Generator/ParameterGenerator.php
+++ b/src/Generator/ParameterGenerator.php
@@ -96,7 +96,7 @@ class ParameterGenerator extends AbstractGenerator
     {
         if (!isset($array['name'])) {
             throw new Exception\InvalidArgumentException(
-                'Paramerer generator requires that a name is provided for this object'
+                'Parameter generator requires that a name is provided for this object'
             );
         }
 
@@ -164,12 +164,19 @@ class ParameterGenerator extends AbstractGenerator
 
     /**
      * @param  mixed $type
+     * @throws Exception\InvalidArgumentException
      * @return ParameterGenerator
      */
     public function setType($type)
     {
+        if (is_array($type) && !isset($type['name'])) {
+            throw new Exception\InvalidArgumentException(
+                'Type generator requires that a name is provided for this object'
+            );
+        }
+
         if (is_array($type)) {
-            $this->type = TypeGenerator::fromTypeArray($type);
+            $this->type = TypeGenerator::fromTypeString($type['name'], true);
             return $this;
         }
 
@@ -177,6 +184,10 @@ class ParameterGenerator extends AbstractGenerator
             $this->type = TypeGenerator::fromTypeString($type);
             return $this;
         }
+
+        throw new Exception\InvalidArgumentException(
+            'Unknown parameter type passed in'
+        );
     }
 
     /**

--- a/src/Generator/ParameterGenerator.php
+++ b/src/Generator/ParameterGenerator.php
@@ -163,25 +163,19 @@ class ParameterGenerator extends AbstractGenerator
     }
 
     /**
-     * @param  mixed $type
+     * @param  string|TypeGenerator $type
      * @throws Exception\InvalidArgumentException
      * @return ParameterGenerator
      */
     public function setType($type)
     {
-        if (is_array($type) && !isset($type['name'])) {
-            throw new Exception\InvalidArgumentException(
-                'Type generator requires that a name is provided for this object'
-            );
-        }
-
-        if (is_array($type)) {
-            $this->type = TypeGenerator::fromTypeString($type['name'], true);
+        if (is_string($type)) {
+            $this->type = TypeGenerator::fromTypeString($type);
             return $this;
         }
 
-        if (is_string($type)) {
-            $this->type = TypeGenerator::fromTypeString($type);
+        if ($type instanceof TypeGenerator) {
+            $this->type = $type;
             return $this;
         }
 

--- a/src/Generator/TypeGenerator.php
+++ b/src/Generator/TypeGenerator.php
@@ -26,7 +26,7 @@ final class TypeGenerator implements GeneratorInterface
     /**
      * @var string;
      */
-    private $alias = false;
+    private $aliased = false;
 
     /**
      * @var string[]
@@ -98,7 +98,7 @@ final class TypeGenerator implements GeneratorInterface
         $instance = self::fromTypeString($typeArray['name']);
 
         if (isset($typeArray['alias']) && is_bool($typeArray['alias'])) {
-            $instance->alias = (boolean) $typeArray['alias'];
+            $instance->aliased = (boolean) $typeArray['alias'];
         }
 
         return $instance;
@@ -117,7 +117,7 @@ final class TypeGenerator implements GeneratorInterface
             return strtolower($this->type);
         }
 
-        return ($this->isAlias()) ? $this->type : '\\' . $this->type;
+        return ($this->aliased) ? $this->type : '\\' . $this->type;
     }
 
     /**
@@ -151,10 +151,5 @@ final class TypeGenerator implements GeneratorInterface
     private static function isInternalPhpType($type)
     {
         return in_array(strtolower($type), self::$internalPhpTypes, true);
-    }
-
-    private function isAlias()
-    {
-        return $this->alias;
     }
 }

--- a/src/Generator/TypeGenerator.php
+++ b/src/Generator/TypeGenerator.php
@@ -24,6 +24,11 @@ final class TypeGenerator implements GeneratorInterface
     private $type;
 
     /**
+     * @var string;
+     */
+    private $alias = false;
+
+    /**
      * @var string[]
      *
      * @link http://php.net/manual/en/functions.arguments.php#functions.arguments.type-declaration
@@ -73,6 +78,32 @@ final class TypeGenerator implements GeneratorInterface
         return $instance;
     }
 
+    /**
+     *  @param array $typeArray
+     *
+     *  @return TypeGenerator
+     *
+     *  @throws InvalidArgumentException
+     */
+    public static function fromTypeArray(array $typeArray)
+    {
+        if (!isset($typeArray['name'])) {
+            throw new InvalidArgumentException(sprintf(
+                'Provided type "%s" is invalid: must conform "%s"',
+                var_export($typeArray, true),
+                self::$validIdentifierMatcher
+            ));
+        }
+
+        $instance = self::fromTypeString($typeArray['name']);
+
+        if (isset($typeArray['alias']) && is_bool($typeArray['alias'])) {
+            $instance->alias = (boolean) $typeArray['alias'];
+        }
+
+        return $instance;
+    }
+
     private function __construct()
     {
     }
@@ -86,7 +117,7 @@ final class TypeGenerator implements GeneratorInterface
             return strtolower($this->type);
         }
 
-        return '\\' . $this->type;
+        return ($this->isAlias()) ? $this->type : '\\' . $this->type;
     }
 
     /**
@@ -120,5 +151,10 @@ final class TypeGenerator implements GeneratorInterface
     private static function isInternalPhpType($type)
     {
         return in_array(strtolower($type), self::$internalPhpTypes, true);
+    }
+
+    private function isAlias()
+    {
+        return $this->alias;
     }
 }

--- a/src/Generator/TypeGenerator.php
+++ b/src/Generator/TypeGenerator.php
@@ -49,7 +49,7 @@ final class TypeGenerator implements GeneratorInterface
      *
      * @throws InvalidArgumentException
      */
-    public static function fromTypeString($type)
+    public static function fromTypeString($type, $aliased = false)
     {
         list($wasTrimmed, $trimmedType) = self::trimType($type);
 
@@ -74,32 +74,7 @@ final class TypeGenerator implements GeneratorInterface
 
         $instance->type              = $trimmedType;
         $instance->isInternalPhpType = self::isInternalPhpType($trimmedType);
-
-        return $instance;
-    }
-
-    /**
-     *  @param array $typeArray
-     *
-     *  @return TypeGenerator
-     *
-     *  @throws InvalidArgumentException
-     */
-    public static function fromTypeArray(array $typeArray)
-    {
-        if (!isset($typeArray['name'])) {
-            throw new InvalidArgumentException(sprintf(
-                'Provided type "%s" is invalid: must conform "%s"',
-                var_export($typeArray, true),
-                self::$validIdentifierMatcher
-            ));
-        }
-
-        $instance = self::fromTypeString($typeArray['name']);
-
-        if (isset($typeArray['alias']) && is_bool($typeArray['alias'])) {
-            $instance->aliased = (boolean) $typeArray['alias'];
-        }
+        $instance->aliased           = (boolean) $aliased;
 
         return $instance;
     }

--- a/test/Generator/ParameterGeneratorTest.php
+++ b/test/Generator/ParameterGeneratorTest.php
@@ -9,8 +9,10 @@
 
 namespace ZendTest\Code\Generator;
 
+use Zend\Code\Exception\InvalidArgumentException;
 use Zend\Code\Generator\ParameterGenerator;
 use Zend\Code\Generator\ValueGenerator;
+use Zend\Code\Generator\TypeGenerator;
 use Zend\Code\Reflection\ParameterReflection;
 use ZendTest\Code\TestAsset\ClassTypeHintedClass;
 use ZendTest\Code\TestAsset\DocBlockOnlyHintsClass;
@@ -28,6 +30,21 @@ class ParameterGeneratorTest extends \PHPUnit_Framework_TestCase
         $parameterGenerator = new ParameterGenerator();
         $parameterGenerator->setType('Foo');
         $this->assertEquals('Foo', $parameterGenerator->getType());
+    }
+
+    public function testTypeSetterWithTypeGenerator()
+    {
+        $parameterGenerator = new ParameterGenerator();
+        $parameterGenerator->setType(TypeGenerator::fromTypeString('Foo'));
+        $this->assertEquals('Foo', $parameterGenerator->getType());
+    }
+
+    public function testTypeSetterRejectInvalidType()
+    {
+        $this->setExpectedException(InvalidArgumentException::class);
+
+        $parameterGenerator = new ParameterGenerator();
+        $parameterGenerator->setType(new \stdclass);
     }
 
     public function testNameGetterAndSetterPersistValue()

--- a/test/Generator/TypeGeneratorTest.php
+++ b/test/Generator/TypeGeneratorTest.php
@@ -80,6 +80,87 @@ class TypeGeneratorTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @dataProvider validTypeArrayProvider
+     *
+     * @param string $typeArray
+     * @param string $expectedReturnType
+     */
+    public function testFromValidStringAlias(array $typeArray, string $expectedReturnType)
+    {
+        $generator = TypeGenerator::fromTypeArray($typeArray);
+
+        self::assertSame($expectedReturnType, $generator->generate());
+    }
+
+    public function validTypeArrayProvider()
+    {
+        return [
+            [['name' => 'foo', 'alias' => true], 'foo'],
+            [['name' => 'foo', 'alias' => false], '\\foo'],
+            [['name' => '\\foo', 'alias' => false], '\\foo'],
+            [['name' => '\\foo', 'alias' => true], 'foo'],
+            [['name' => 'a\\b\\c', 'alias' => false], '\\a\\b\\c'],
+            [['name' => 'a\\b\\c', 'alias' => true], 'a\\b\\c'],
+            [['name' => 'array', 'alias' => false], 'array'],
+            [['name' => 'array', 'alias' => true], 'array'],
+            [['name' => 'Array', 'alias' => false], 'array'],
+            [['name' => 'Array', 'alias' => true], 'array'],
+            [['name' => 'ARRAY', 'alias' => false], 'array'],
+            [['name' => 'ARRAY', 'alias' => true], 'array'],
+            [['name' => 'callable', 'alias' => false], 'callable'],
+            [['name' => 'callable', 'alias' => true], 'callable'],
+            [['name' => 'Callable', 'alias' => false], 'callable'],
+            [['name' => 'Callable', 'alias' => true], 'callable'],
+            [['name' => 'CALLABLE', 'alias' => false], 'callable'],
+            [['name' => 'CALLABLE', 'alias' => true], 'callable'],
+            [['name' => 'string', 'alias' => false], 'string'],
+            [['name' => 'string', 'alias' => true], 'string'],
+            [['name' => 'String', 'alias' => false], 'string'],
+            [['name' => 'String', 'alias' => true], 'string'],
+            [['name' => 'STRING', 'alias' => false], 'string'],
+            [['name' => 'STRING', 'alias' => true], 'string'],
+            [['name' => 'int', 'alias' => false], 'int'],
+            [['name' => 'int', 'alias' => true], 'int'],
+            [['name' => 'Int', 'alias' => false], 'int'],
+            [['name' => 'Int', 'alias' => true], 'int'],
+            [['name' => 'INT', 'alias' => false], 'int'],
+            [['name' => 'INT', 'alias' => true], 'int'],
+            [['name' => 'float', 'alias' => false], 'float'],
+            [['name' => 'float', 'alias' => true], 'float'],
+            [['name' => 'Float', 'alias' => false], 'float'],
+            [['name' => 'Float', 'alias' => true], 'float'],
+            [['name' => 'FLOAT', 'alias' => false], 'float'],
+            [['name' => 'FLOAT', 'alias' => true], 'float'],
+            [['name' => 'bool', 'alias' => false], 'bool'],
+            [['name' => 'bool', 'alias' => true], 'bool'],
+            [['name' => 'Bool', 'alias' => false], 'bool'],
+            [['name' => 'Bool', 'alias' => true], 'bool'],
+            [['name' => 'BOOL', 'alias' => false], 'bool'],
+            [['name' => 'BOOL', 'alias' => true], 'bool'],
+            [['name' => 'object', 'alias' => false], '\\object'],
+            [['name' => 'object', 'alias' => true], 'object'],
+            [['name' => 'Object', 'alias' => false], '\\Object'],
+            [['name' => 'Object', 'alias' => true], 'Object'],
+            [['name' => 'OBJECT', 'alias' => false], '\\OBJECT'],
+            [['name' => 'OBJECT', 'alias' => true], 'OBJECT'],
+            [['name' => 'mixed', 'alias' => false], '\\mixed'],
+            [['name' => 'mixed', 'alias' => true], 'mixed'],
+            [['name' => 'Mixed', 'alias' => false], '\\Mixed'],
+            [['name' => 'Mixed', 'alias' => true], 'Mixed'],
+            [['name' => 'MIXED', 'alias' => false], '\\MIXED'],
+            [['name' => 'MIXED', 'alias' => true], 'MIXED'],
+            [['name' => 'resource', 'alias' => false], '\\resource'],
+            [['name' => 'resource', 'alias' => true], 'resource'],
+            [['name' => 'Resource', 'alias' => false], '\\Resource'],
+            [['name' => 'Resource', 'alias' => true], 'Resource'],
+            [['name' => 'RESOURCE', 'alias' => false], '\\RESOURCE'],
+            [['name' => 'RESOURCE', 'alias' => true], 'RESOURCE'],
+            [['name' => 'foo_bar', 'alias' => false], '\\foo_bar'],
+            [['name' => 'foo_bar', 'alias' => true], 'foo_bar'],
+        ];
+    }
+
+    /**
      * @return string[][]
      */
     public function validTypeProvider()

--- a/test/Generator/TypeGeneratorTest.php
+++ b/test/Generator/TypeGeneratorTest.php
@@ -87,7 +87,7 @@ class TypeGeneratorTest extends \PHPUnit_Framework_TestCase
      */
     public function testFromValidStringAlias(array $typeArray, string $expectedReturnType)
     {
-        $generator = TypeGenerator::fromTypeArray($typeArray);
+        $generator = TypeGenerator::fromTypeString($typeArray['name'], $typeArray['alias']);
 
         self::assertSame($expectedReturnType, $generator->generate());
     }


### PR DESCRIPTION
When a use statements is declared we should be able to use alias as type
for parameters. This patch keep the current behavior and add a way to
define if the parameter type is an alias or not.
