### PR TITLE
Fix undefined offset in MethodGenerator

### DIFF
--- a/src/Generator/MethodGenerator.php
+++ b/src/Generator/MethodGenerator.php
@@ -94,10 +94,10 @@ class MethodGenerator extends AbstractMemberGenerator
         }
 
         $lines = explode(PHP_EOL, $body);
-        
+
         if (count($lines) > 1) {
             $indention = str_replace(trim($lines[1]), '', $lines[1]);
-    
+
             foreach ($lines as $key => $line) {
                 if (substr($line, 0, strlen($indention)) == $indention) {
                     $lines[$key] = substr($line, strlen($indention));

--- a/src/Generator/MethodGenerator.php
+++ b/src/Generator/MethodGenerator.php
@@ -103,11 +103,11 @@ class MethodGenerator extends AbstractMemberGenerator
                     $lines[$key] = substr($line, strlen($indention));
                 }
             }
-        } else {
-            $lines[0] = trim($lines[0]);
-        }
 
-        $body = implode(PHP_EOL, $lines);
+            $body = implode(PHP_EOL, $lines);
+        } else {
+            $body = trim($body);
+        }
 
         return $body;
     }

--- a/src/Generator/MethodGenerator.php
+++ b/src/Generator/MethodGenerator.php
@@ -94,12 +94,14 @@ class MethodGenerator extends AbstractMemberGenerator
         }
 
         $lines = explode(PHP_EOL, $body);
-
-        $indention = str_replace(trim($lines[1]), '', $lines[1]);
-
-        foreach ($lines as $key => $line) {
-            if (substr($line, 0, strlen($indention)) == $indention) {
-                $lines[$key] = substr($line, strlen($indention));
+        
+        if (count($lines) > 1) {
+            $indention = str_replace(trim($lines[1]), '', $lines[1]);
+    
+            foreach ($lines as $key => $line) {
+                if (substr($line, 0, strlen($indention)) == $indention) {
+                    $lines[$key] = substr($line, strlen($indention));
+                }
             }
         }
 

--- a/src/Generator/MethodGenerator.php
+++ b/src/Generator/MethodGenerator.php
@@ -103,6 +103,8 @@ class MethodGenerator extends AbstractMemberGenerator
                     $lines[$key] = substr($line, strlen($indention));
                 }
             }
+        } else {
+            $lines[0] = trim($lines[0]);
         }
 
         $body = implode(PHP_EOL, $lines);


### PR DESCRIPTION
Running symfony2 `app/console cache:clear` with `zend-code` version `>= 3.0.0` gives this notice:

```
Notice: Undefined offset: 1 in {path}\vendor\zendframework\zend-code\src\Generator\MethodGenerator.php on line 98
PHP Notice:  Undefined offset: 1 in {path}\vendor\zendframework\zend-code\src\Generator\MethodGenerator.php on line 98
```

This PR fixes that adding a simple check.