### PR TITLE
Fix exploding a string

### DIFF
--- a/src/Generator/MethodGenerator.php
+++ b/src/Generator/MethodGenerator.php
@@ -93,7 +93,7 @@ class MethodGenerator extends AbstractMemberGenerator
             return $body;
         }
 
-        $lines = explode(PHP_EOL, $body);
+        $lines = explode("\n", $body);
 
         $indention = str_replace(trim($lines[1]), '', $lines[1]);
 


### PR DESCRIPTION
The protected method Zend\Code\Reflection\MethodReflection::extractMethodContents ignores new line characters from the file and implodes lines using "\n".

Then we're exploding the method body with character PHP_EOL. It's not a cross platform and for cases other than "\n" the result of this function is an array with one element (whole body) so the $lines[1] is unset.

IMHO #47 is the example. 