### PR TITLE
Updated dependencies to allow stdlib v3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: php
 
 branches:
   except:
-    - /^release-.*$/
+    - /^release-\d+\.\d+\.\d+.*$/
     - /^ghgfk-.*$/
 
 cache:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
-## 2.6.2 - TBD
+## 2.6.3 - 2016-04-20
 
 ### Added
 
@@ -18,7 +18,27 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
+- [#51](https://github.com/zendframework/zend-code/pull/51) updates the
+  zend-stdlib dependency to allow either 2.7 or 3.0 releases, as the
+  functionality consumed maintains its API between releases.
+
+## 2.6.2 - 2016-01-05
+
+### Added
+
 - Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- [#31](https://github.com/zendframework/zend-code/pull/31) updated license year.
 
 ## 2.6.1 - 2015-11-24
 

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "doctrine/annotations": "~1.0",
         "zendframework/zend-stdlib": "^2.7 || ^3.0",
         "fabpot/php-cs-fixer": "1.7.*",
-        "phpunit/PHPUnit": "^4.5"
+        "phpunit/PHPUnit": "^4.8.21"
     },
     "suggest": {
         "doctrine/annotations": "Doctrine\\Common\\Annotations >=1.0 for annotation features",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     },
     "require": {
-        "php": "^5.5 || ^7.0",
+        "php": "^5.5 || 7.0.0 - 7.0.4 || ^7.0.6",
         "zendframework/zend-eventmanager": "^2.6 || ^3.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -13,14 +13,14 @@
         }
     },
     "require": {
-        "php": ">=5.5",
-        "zendframework/zend-eventmanager": "^2.6|^3.0"
+        "php": "^5.5 || ^7.0",
+        "zendframework/zend-eventmanager": "^2.6 || ^3.0"
     },
     "require-dev": {
         "doctrine/annotations": "~1.0",
-        "zendframework/zend-stdlib": "~2.7",
+        "zendframework/zend-stdlib": "^2.7 || ^3.0",
         "fabpot/php-cs-fixer": "1.7.*",
-        "phpunit/PHPUnit": "~4.0"
+        "phpunit/PHPUnit": "^4.5"
     },
     "suggest": {
         "doctrine/annotations": "Doctrine\\Common\\Annotations >=1.0 for annotation features",


### PR DESCRIPTION
This patch updates the 2.6 series to allow using zend-stdlib 2.7 **or** 3.0 releases. The only functionality used from zend-stdlib is the `ArrayObject` implementation, which maintains compatibility across versions.