### PR TITLE
Updated stdlib requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require-dev": {
         "ext-phar": "*",
         "doctrine/annotations": "~1.0",
-        "zendframework/zend-stdlib": "~2.7",
+        "zendframework/zend-stdlib": "^2.7 || ^3.0",
         "squizlabs/php_codesniffer": "^2.5",
         "phpunit/PHPUnit": "^4.8.21"
     },

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     },
     "require": {
-        "php": "^5.5 || ^7.0",
+        "php": "^5.5 || 7.0.0 - 7.0.4 || ^7.0.6",
         "zendframework/zend-eventmanager": "^2.6 || ^3.0"
     },
     "require-dev": {

--- a/src/Scanner/ClassScanner.php
+++ b/src/Scanner/ClassScanner.php
@@ -919,7 +919,6 @@ class ClassScanner implements ScannerInterface
         SCANNER_TOP:
 
         switch ($tokenType) {
-
             case T_DOC_COMMENT:
                 $this->docComment = $tokenContent;
                 goto SCANNER_CONTINUE;
@@ -944,7 +943,6 @@ class ClassScanner implements ScannerInterface
                 $this->lineStart = $tokenLine;
 
                 switch ($tokenType) {
-
                     case T_FINAL:
                         $this->isFinal = true;
                         goto SCANNER_CLASS_INFO_CONTINUE;
@@ -1008,7 +1006,6 @@ class ClassScanner implements ScannerInterface
                             $classInterfaceIndex++;
                             $this->shortInterfaces[$classInterfaceIndex] = '';
                         }
-
                 }
 
                 SCANNER_CLASS_INFO_CONTINUE:
@@ -1021,7 +1018,6 @@ class ClassScanner implements ScannerInterface
                 SCANNER_CLASS_INFO_END:
 
                 goto SCANNER_CONTINUE;
-
         }
 
         if ($tokenType === null && $tokenContent === '{' && $braceCount === 0) {
@@ -1037,7 +1033,6 @@ class ClassScanner implements ScannerInterface
             }
 
             switch ($tokenType) {
-
                 case T_CONST:
                     $infos[$infoIndex] = [
                         'type'          => 'constant',
@@ -1239,7 +1234,6 @@ class ClassScanner implements ScannerInterface
                     }
 
                     switch ($tokenType) {
-
                         case T_CONST:
                             $memberContext             = 'constant';
                             $infos[$infoIndex]['type'] = 'constant';

--- a/src/Scanner/DocBlockScanner.php
+++ b/src/Scanner/DocBlockScanner.php
@@ -159,7 +159,6 @@ class DocBlockScanner implements ScannerInterface
 
             case 'DOCBLOCK_COMMENTEND':
                 goto SCANNER_END;
-
         }
 
         SCANNER_CONTINUE:


### PR DESCRIPTION
Updated to allow either 2.7 or 3.0 releases, as the functionality used does not change API between versions.

This also updates the PHP constraint to disallow PHP 7.0.5, fixing #49.