### PR TITLE
Do not allow PHP version 7.0.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     },
     "require": {
-        "php": ">=5.3.23",
+        "php": ">=5.3.23, !=7.0.5",
         "zendframework/zend-eventmanager": "self.version"
     },
     "require-dev": {


### PR DESCRIPTION
As reported in zendframework/zend-code#49 PHP version 7.0.5 is not compatible if you are using zend annotations. this was fixed in the 3.x branch. This is a fix for legacy version