### PR TITLE
Resolve issues with traits in ClassScanner

### DIFF
--- a/src/Scanner/ClassScanner.php
+++ b/src/Scanner/ClassScanner.php
@@ -547,6 +547,8 @@ class ClassScanner implements ScannerInterface
      */
     public function getTraitNames()
     {
+        $this->scan();
+
         $return = [];
         foreach ($this->infos as $info) {
             if ($info['type'] !== 'use') {
@@ -562,7 +564,6 @@ class ClassScanner implements ScannerInterface
                     $return[] = $traitName;
                 }
             }
-            break;
         }
 
         return $return;
@@ -575,6 +576,8 @@ class ClassScanner implements ScannerInterface
      */
     public function getTraitAliases()
     {
+        $this->scan();
+
         $return = [];
         foreach ($this->infos as $info) {
             if ($info['type'] !== 'use') {
@@ -598,7 +601,6 @@ class ClassScanner implements ScannerInterface
                     $return[$alias['alias']] = $trait . '::' . $method;
                 }
             }
-            break;
         }
 
         return $return;
@@ -612,6 +614,8 @@ class ClassScanner implements ScannerInterface
      */
     protected function getVisibilityForAlias($aliasName)
     {
+        $this->scan();
+
         $return = null;
         foreach ($this->infos as $info) {
             if ($info['type'] !== 'use') {
@@ -632,7 +636,6 @@ class ClassScanner implements ScannerInterface
                     }
                 }
             }
-            break;
         }
 
         return $return;
@@ -645,6 +648,8 @@ class ClassScanner implements ScannerInterface
      */
     protected function getBlockedTraitMethods()
     {
+        $this->scan();
+
         $return = [];
         foreach ($this->infos as $info) {
             if ($info['type'] !== 'use') {
@@ -668,7 +673,6 @@ class ClassScanner implements ScannerInterface
                     $return[] = $trait . '::' . $method;
                 }
             }
-            break;
         }
 
         return $return;

--- a/test/Scanner/ClassScannerTest.php
+++ b/test/Scanner/ClassScannerTest.php
@@ -202,6 +202,7 @@ class ClassScannerTest extends TestCase
         $class->getTraitAliases();
         $this->assertContains('ZendTest\Code\TestAsset\BarTrait', $traitNames);
         $this->assertContains('ZendTest\Code\TestAsset\FooTrait', $traitNames);
+        $this->assertContains('ZendTest\Code\TestAsset\BazTrait', $traitNames);
     }
 
     /**

--- a/test/TestAsset/BazTrait.php
+++ b/test/TestAsset/BazTrait.php
@@ -9,10 +9,9 @@
 
 namespace ZendTest\Code\TestAsset;
 
-use ZendTest\Code\TestAsset\FooTrait;
-
-class TestClassUsesTraitSimple
+trait BazTrait
 {
-    use \ZendTest\Code\TestAsset\BarTrait, FooTrait;
-    use BazTrait;
+    public function baz()
+    {
+    }
 }


### PR DESCRIPTION
- Only the first use statement would be accounted for when getting lists
  of traits, due to unnecessary break statements at the end of the loop.
  Fixes #58
- If one of the methods touched by this commit, such as getTraitNames(),
  or getTraits(), which calls getTraitNames(), was called as the first
  action on this class, no traits would be returned, due to the fact
  that scan() was not called at the start of the method. Fixes #57