### PR TITLE
Fix handling of FQCNs in method parameters

### DIFF
--- a/src/Scanner/MethodScanner.php
+++ b/src/Scanner/MethodScanner.php
@@ -522,6 +522,12 @@ class MethodScanner implements ScannerInterface
                 goto SCANNER_CONTINUE_SIGNATURE;
                 // goto (no break needed);
 
+            case T_NS_SEPARATOR:
+                if (!isset($infos[$infoIndex])) {
+                    $MACRO_INFO_START();
+                }
+                goto SCANNER_CONTINUE_SIGNATURE;
+
             case T_VARIABLE:
             case T_STRING:
                 if ($tokenType === T_STRING && $parentCount === 0) {

--- a/src/Scanner/MethodScanner.php
+++ b/src/Scanner/MethodScanner.php
@@ -527,6 +527,7 @@ class MethodScanner implements ScannerInterface
                     $MACRO_INFO_START();
                 }
                 goto SCANNER_CONTINUE_SIGNATURE;
+                // goto (no break needed);
 
             case T_VARIABLE:
             case T_STRING:

--- a/test/Scanner/ClassScannerTest.php
+++ b/test/Scanner/ClassScannerTest.php
@@ -160,7 +160,7 @@ class ClassScannerTest extends TestCase
         $file    = new FileScanner(__DIR__ . '/../TestAsset/BarClass.php');
         $class   = $file->getClass('ZendTest\Code\TestAsset\BarClass');
         $this->assertEquals(10, $class->getLineStart());
-        $this->assertEquals(37, $class->getLineEnd());
+        $this->assertEquals(42, $class->getLineEnd());
     }
 
     public function testClassScannerCanScanAnnotations()

--- a/test/Scanner/MethodScannerTest.php
+++ b/test/Scanner/MethodScannerTest.php
@@ -48,6 +48,16 @@ class MethodScannerTest extends TestCase
         $this->assertEquals('t', $parameter->getName());
     }
 
+    public function testMethodScannerParsesClassNames()
+    {
+        $file   = new FileScanner(__DIR__ . '/../TestAsset/BarClass.php');
+        $class  = $file->getClass('ZendTest\Code\TestAsset\BarClass');
+        $method = $class->getMethod('five');
+        $this->assertEquals(['a'], $method->getParameters());
+        $parameter = $method->getParameter('a');
+        $this->assertEquals('ZendTest\Code\TestAsset\AbstractClass', $parameter->getClass());
+    }
+
     public function testMethodScannerReturnsPropertyWithNoDefault()
     {
         $file  = new FileScanner(__DIR__ . '/../TestAsset/BazClass.php');

--- a/test/TestAsset/BarClass.php
+++ b/test/TestAsset/BarClass.php
@@ -34,4 +34,9 @@ abstract class BarClass
     {
         // four
     }
+
+    private function five(\ZendTest\Code\TestAsset\AbstractClass $a)
+    {
+        // five
+    }
 }


### PR DESCRIPTION
Previously, `MethodScanner` did not detect a leading `T_NS_SEPARATOR`
character for a type name. By failing to detect it, it passes it to
`ParameterScanner` without it, who then dutifully resolves the classname
as if it was relative to the current namespace.

This is obviously incorrect behaviour, and it is fixed with this patch.
Tests have also been added and updated.