### PR TITLE
Use correct class names in the ClassGenerator implements and extend.

### DIFF
--- a/src/Generator/ClassGenerator.php
+++ b/src/Generator/ClassGenerator.php
@@ -950,12 +950,13 @@ class ClassGenerator extends AbstractGenerator
         $output .= static::OBJECT_TYPE . ' ' . $this->getName();
 
         if (!empty($this->extendedClass)) {
-            $output .= ' extends ' . $this->extendedClass;
+            $output .= ' extends ' .  $this->generateShortOrCompleteClassname($this->extendedClass);
         }
 
         $implemented = $this->getImplementedInterfaces();
 
         if (!empty($implemented)) {
+            $implemented = array_map([$this, 'generateShortOrCompleteClassname'], $implemented);
             $output .= ' ' . static::IMPLEMENTS_KEYWORD . ' ' . implode(', ', $implemented);
         }
 
@@ -1008,5 +1009,24 @@ class ClassGenerator extends AbstractGenerator
             'Expected value for constant, value must be a "scalar" or "null", "%s" found',
             gettype($value)
         ));
+    }
+
+    /**
+     * @param string $fqnClassName
+     *
+     * @return string
+     */
+    private function generateShortOrCompleteClassname($fqnClassName)
+    {
+        $parts = explode('\\', $fqnClassName);
+        $className = array_pop($parts);
+        $classNamespace = implode('\\', $parts);
+        $currentNamespace = (string) $this->getNamespaceName();
+
+        if ($classNamespace === $currentNamespace || in_array($fqnClassName, $this->getUses())) {
+            return $className;
+        }
+
+        return '\\' . $fqnClassName;
     }
 }

--- a/test/Generator/ClassGeneratorTest.php
+++ b/test/Generator/ClassGeneratorTest.php
@@ -242,8 +242,8 @@ EOS;
         $code = $classGenerator->generate();
 
         $expectedClassDef = 'class ClassWithInterface'
-            . ' implements ZendTest\Code\Generator\TestAsset\OneInterface'
-            . ', ZendTest\Code\Generator\TestAsset\TwoInterface';
+            . ' implements OneInterface'
+            . ', TwoInterface';
         $this->assertContains($expectedClassDef, $code);
     }
 
@@ -260,8 +260,8 @@ EOS;
         $code = $classGenerator->generate();
 
         $expectedClassDef = 'class NewClassWithInterface'
-            . ' extends ZendTest\Code\Generator\TestAsset\ClassWithInterface'
-            . ' implements ZendTest\Code\Generator\TestAsset\ThreeInterface';
+            . ' extends ClassWithInterface'
+            . ' implements ThreeInterface';
         $this->assertContains($expectedClassDef, $code);
     }
 
@@ -1084,5 +1084,42 @@ EOS;
 
         $output = $classGenerator->generate();
         $this->assertEquals($expectedOutput, $output, $output);
+    }
+
+    public function testCorrectExtendNames()
+    {
+        $classGenerator = new ClassGenerator();
+        $classGenerator->setName('ClassName');
+        $classGenerator->setNamespaceName('SomeNamespace');
+        $classGenerator->addUse('Zend\Code\NameInformation');
+        $classGenerator->setExtendedClass('Zend\Code\NameInformation');
+        $this->assertContains('class ClassName extends NameInformation', $classGenerator->generate());
+
+        $classGenerator = new ClassGenerator();
+        $classGenerator->setName('ClassName');
+        $classGenerator->setNamespaceName('SomeNamespace');
+        $classGenerator->setExtendedClass('DateTime');
+        $this->assertContains('class ClassName extends \DateTime', $classGenerator->generate());
+
+        $classGenerator = new ClassGenerator();
+        $classGenerator->setName('ClassName');
+        $classGenerator->setExtendedClass('DateTime');
+        $this->assertContains('class ClassName extends DateTime', $classGenerator->generate());
+    }
+
+    public function testCorrectImplementNames()
+    {
+        $classGenerator = new ClassGenerator();
+        $classGenerator->setName('ClassName');
+        $classGenerator->setNamespaceName('SomeNamespace');
+        $classGenerator->addUse('Zend\Code\Generator\GeneratorInterface');
+        $classGenerator->setImplementedInterfaces([
+           'SomeNamespace\ClassInterface',
+           'Zend\Code\Generator\GeneratorInterface',
+           'Iteratable'
+        ]);
+
+        $expected = 'class ClassName implements ClassInterface, GeneratorInterface, \Iteratable';
+        $this->assertContains($expected, $classGenerator->generate());
     }
 }


### PR DESCRIPTION
This PR fixes #64. It will try to look for the classnames in the use statements and will validate if the classes live in the same namespace as the class that is being generated.
If this is the case, the short classname is being used instead of the full classname.
If this is not the case, the backslash is added to make sure that the classes can be loaded by PHP.
