### PR TITLE
Provide a fix for issue #70

### DIFF
--- a/src/Scanner/TokenArrayScanner.php
+++ b/src/Scanner/TokenArrayScanner.php
@@ -583,7 +583,9 @@ class TokenArrayScanner implements ScannerInterface
                         && $infos[$infoIndex]['type'] === 'class'
                         || ($tokenType === T_FUNCTION && $infos[$infoIndex]['type'] === 'function'))
                 ) {
-                    $infos[$infoIndex]['shortName'] = $tokens[$tokenIndex + 2][1];
+                    $infos[$infoIndex]['shortName'] = is_array($tokens[$tokenIndex + 2])
+                        ? $tokens[$tokenIndex + 2][1]
+                        : $tokens[$tokenIndex + 2];
                     $infos[$infoIndex]['name']      = (($namespace !== null)
                         ? $namespace . '\\'
                         : '') . $infos[$infoIndex]['shortName'];

--- a/test/Reflection/FileReflectionTest.php
+++ b/test/Reflection/FileReflectionTest.php
@@ -175,4 +175,16 @@ class FileReflectionTest extends \PHPUnit_Framework_TestCase
             ];
         $this->assertSame($expected, $reflectionFile->getUses());
     }
+
+    /**
+     * @group 70
+     * @group 43
+     */
+    public function testFileReflectionShouldNotRaiseNoticesWhenReflectingClosures()
+    {
+        require_once __DIR__ . '/TestAsset/issue-70.php';
+        $r = new FileReflection(__DIR__ . '/TestAsset/issue-70.php');
+        $this->assertContains('spl_autoload_register', $r->getContents());
+        $this->assertContains('function ()', $r->getContents());
+    }
 }

--- a/test/Reflection/TestAsset/issue-70.php
+++ b/test/Reflection/TestAsset/issue-70.php
@@ -1,0 +1,9 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-code for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+spl_autoload_register(function () {
+});


### PR DESCRIPTION
- Added a failing test case, per #70.
- Discovered that the structure addressed can be either an array (existing assumption) or a string.
- Updated the assignment to check for array before assigning, and use the string value if present instead.

Fixes #70.
Fixes #43.