### PR TITLE
ensure there is only 1 leading NS_SEPARATOR

### DIFF
--- a/src/Generator/ClassGenerator.php
+++ b/src/Generator/ClassGenerator.php
@@ -1027,6 +1027,6 @@ class ClassGenerator extends AbstractGenerator
             return $className;
         }
 
-        return '\\' . $fqnClassName;
+        return '\\' . trim($fqnClassName, '\\');
     }
 }


### PR DESCRIPTION
Bug intriduced in 4a6f4ab33480923ac6553ded903c97de168f37fe

@Ocramius can you please look at this patch.

It seems ProxyManager is broken because of this bug, tons of classes are generated with 2 leading NS_SEPARATOR

Example: 

     class Foo5773ef989dcd4778751139 implements \\ProxyManager\Proxy\RemoteObjectInterface, \\ProxyManagerTestAsset\RemoteProxy\FooServiceInterface

Which raise Parse Errors during proxymanager test suite.

     9) ProxyManagerTest\Functional\RemoteObjectFunctionalTest::testJsonRpcMethodCalls with data set #3 ('ProxyManagerTestAsset\RemoteP...erface', 'baz', array('baz'), 'baz remote')
     ParseError: syntax error, unexpected \\ (T_NS_SEPARATOR), expecting identifier (T_STRING)
