### PR TITLE
1. Fix ClassScanner::getInterfaces() which don't work with Interface.

### DIFF
--- a/src/Scanner/ClassScanner.php
+++ b/src/Scanner/ClassScanner.php
@@ -985,9 +985,9 @@ class ClassScanner implements ScannerInterface
                     case T_STRING:
                         switch ($classContext) {
                             case T_EXTENDS:
-                                if( $this->isInterface ) {
+                                if ($this->isInterface) {
                                     $this->shortInterfaces[$classInterfaceIndex] .= $tokenContent;
-                                }else{
+                                } else {
                                     $this->shortParentClass .= $tokenContent;
                                 }
                                 break;

--- a/src/Scanner/ClassScanner.php
+++ b/src/Scanner/ClassScanner.php
@@ -1010,10 +1010,9 @@ class ClassScanner implements ScannerInterface
                         // goto no break needed
 
                     case null:
-                        if ($classContext == T_IMPLEMENTS && $tokenContent == ',') {
-                            $classInterfaceIndex++;
-                            $this->shortInterfaces[$classInterfaceIndex] = '';
-                        } elseif ($classContext == T_EXTENDS && $tokenContent == ',' && $this->isInterface) {
+                        if (($classContext == T_IMPLEMENTS && $tokenContent == ',')
+                            || ($classContext == T_EXTENDS && $tokenContent == ',' && $this->isInterface))
+                        {
                             $classInterfaceIndex++;
                             $this->shortInterfaces[$classInterfaceIndex] = '';
                         }

--- a/src/Scanner/ClassScanner.php
+++ b/src/Scanner/ClassScanner.php
@@ -1011,8 +1011,7 @@ class ClassScanner implements ScannerInterface
 
                     case null:
                         if (($classContext == T_IMPLEMENTS && $tokenContent == ',')
-                            || ($classContext == T_EXTENDS && $tokenContent == ',' && $this->isInterface))
-                        {
+                            || ($classContext == T_EXTENDS && $tokenContent == ',' && $this->isInterface)) {
                             $classInterfaceIndex++;
                             $this->shortInterfaces[$classInterfaceIndex] = '';
                         }

--- a/src/Scanner/ClassScanner.php
+++ b/src/Scanner/ClassScanner.php
@@ -985,7 +985,11 @@ class ClassScanner implements ScannerInterface
                     case T_STRING:
                         switch ($classContext) {
                             case T_EXTENDS:
-                                $this->shortParentClass .= $tokenContent;
+                                if( $this->isInterface ) {
+                                    $this->shortInterfaces[$classInterfaceIndex] .= $tokenContent;
+                                }else{
+                                    $this->shortParentClass .= $tokenContent;
+                                }
                                 break;
                             case T_IMPLEMENTS:
                                 $this->shortInterfaces[$classInterfaceIndex] .= $tokenContent;
@@ -1006,7 +1010,7 @@ class ClassScanner implements ScannerInterface
                         // goto no break needed
 
                     case null:
-                        if ($classContext == T_IMPLEMENTS && $tokenContent == ',') {
+                        if (( $classContext == T_IMPLEMENTS && $tokenContent == ',' ) || ( $classContext == T_EXTENDS && $tokenContent == ',' && $this->isInterface )) {
                             $classInterfaceIndex++;
                             $this->shortInterfaces[$classInterfaceIndex] = '';
                         }

--- a/src/Scanner/ClassScanner.php
+++ b/src/Scanner/ClassScanner.php
@@ -1010,7 +1010,10 @@ class ClassScanner implements ScannerInterface
                         // goto no break needed
 
                     case null:
-                        if (( $classContext == T_IMPLEMENTS && $tokenContent == ',' ) || ( $classContext == T_EXTENDS && $tokenContent == ',' && $this->isInterface )) {
+                        if ($classContext == T_IMPLEMENTS && $tokenContent == ',') {
+                            $classInterfaceIndex++;
+                            $this->shortInterfaces[$classInterfaceIndex] = '';
+                        } elseif ($classContext == T_EXTENDS && $tokenContent == ',' && $this->isInterface) {
                             $classInterfaceIndex++;
                             $this->shortInterfaces[$classInterfaceIndex] = '';
                         }

--- a/test/Scanner/ClassScannerTest.php
+++ b/test/Scanner/ClassScannerTest.php
@@ -307,4 +307,15 @@ class ClassScannerTest extends TestCase
         $this->assertTrue($class->isTrait());
         $this->assertFalse($class->isInstantiable());
     }
+
+    public function testGetInterfacesFromInterface()
+    {
+        $file  = new FileScanner(__DIR__ . '/../TestAsset/FooInterface.php');
+        $class = $file->getClass('ZendTest\Code\TestAsset\FooInterface');
+        $this->assertTrue($class->isInterface());
+        $this->assertEquals(1, count($class->getInterfaces()));
+        $this->assertEquals('ArrayAccess', $class->getInterfaces()[0]);
+    }
+
+
 }

--- a/test/Scanner/ClassScannerTest.php
+++ b/test/Scanner/ClassScannerTest.php
@@ -316,6 +316,4 @@ class ClassScannerTest extends TestCase
         $this->assertEquals(1, count($class->getInterfaces()));
         $this->assertEquals('ArrayAccess', $class->getInterfaces()[0]);
     }
-
-
 }


### PR DESCRIPTION
1. Fix ClassScanner::getInterfaces() which don't work with Interface.
2. add TestCase  ClassScannerTest::testGetInterfacesFromInterface().

from issue https://github.com/zendframework/zend-code/issues/90