### PR TITLE
Allow arrays as constant values in generated constants

### DIFF
--- a/src/Generator/ValueGenerator.php
+++ b/src/Generator/ValueGenerator.php
@@ -175,6 +175,8 @@ class ValueGenerator extends AbstractGenerator
         // valid types for constants
         $scalarTypes = [
             self::TYPE_ARRAY,
+            self::TYPE_ARRAY_LONG,
+            self::TYPE_ARRAY_SHORT,
             self::TYPE_BOOLEAN,
             self::TYPE_BOOL,
             self::TYPE_NUMBER,

--- a/src/Generator/ValueGenerator.php
+++ b/src/Generator/ValueGenerator.php
@@ -172,8 +172,7 @@ class ValueGenerator extends AbstractGenerator
             $type = $this->type;
         }
 
-        // valid types for constants
-        $scalarTypes = [
+        $validConstantTypes = [
             self::TYPE_ARRAY,
             self::TYPE_ARRAY_LONG,
             self::TYPE_ARRAY_SHORT,
@@ -189,7 +188,7 @@ class ValueGenerator extends AbstractGenerator
             self::TYPE_NULL
         ];
 
-        return in_array($type, $scalarTypes);
+        return in_array($type, $validConstantTypes);
     }
 
     /**

--- a/src/Generator/ValueGenerator.php
+++ b/src/Generator/ValueGenerator.php
@@ -174,6 +174,7 @@ class ValueGenerator extends AbstractGenerator
 
         // valid types for constants
         $scalarTypes = [
+            self::TYPE_ARRAY,
             self::TYPE_BOOLEAN,
             self::TYPE_BOOL,
             self::TYPE_NUMBER,

--- a/test/Generator/ValueGeneratorTest.php
+++ b/test/Generator/ValueGeneratorTest.php
@@ -12,6 +12,8 @@ namespace ZendTest\Code\Generator;
 use ArrayAccess;
 use ArrayObject as SplArrayObject;
 use Zend\Code\Exception\InvalidArgumentException;
+use Zend\Code\Generator\PropertyGenerator;
+use Zend\Code\Generator\PropertyValueGenerator;
 use Zend\Stdlib\ArrayObject as StdlibArrayObject;
 use Zend\Code\Generator\ValueGenerator;
 
@@ -61,6 +63,36 @@ class ValueGeneratorTest extends \PHPUnit_Framework_TestCase
         return [
             SplArrayObject::class => [new SplArrayObject()],
             StdlibArrayObject::class => [new StdlibArrayObject()],
+        ];
+    }
+
+    /**
+     * @dataProvider validConstantTypesProvider
+     */
+    public function testValidConstantTypes($generator)
+    {
+        $propertyGenerator = new PropertyGenerator('FOO', $generator);
+        $propertyGenerator->setConst(true);
+
+        $this->assertInternalType('string', $propertyGenerator->generate());
+    }
+
+    public function validConstantTypesProvider()
+    {
+        return [
+            [new PropertyValueGenerator([], PropertyValueGenerator::TYPE_ARRAY)],
+            [new PropertyValueGenerator([], PropertyValueGenerator::TYPE_ARRAY_LONG)],
+            [new PropertyValueGenerator([], PropertyValueGenerator::TYPE_ARRAY_SHORT)],
+            [new PropertyValueGenerator(true, PropertyValueGenerator::TYPE_BOOL)],
+            [new PropertyValueGenerator(true, PropertyValueGenerator::TYPE_BOOLEAN)],
+            [new PropertyValueGenerator(1, PropertyValueGenerator::TYPE_INT)],
+            [new PropertyValueGenerator(1, PropertyValueGenerator::TYPE_INTEGER)],
+            [new PropertyValueGenerator(0.1, PropertyValueGenerator::TYPE_DOUBLE)],
+            [new PropertyValueGenerator(0.1, PropertyValueGenerator::TYPE_FLOAT)],
+            [new PropertyValueGenerator('bar', PropertyValueGenerator::TYPE_STRING)],
+            [new PropertyValueGenerator(null, PropertyValueGenerator::TYPE_NULL)],
+            [new PropertyValueGenerator(null, PropertyValueGenerator::TYPE_NULL)],
+            [new PropertyValueGenerator('PHP_EOL', PropertyValueGenerator::TYPE_CONSTANT)],
         ];
     }
 

--- a/test/Generator/ValueGeneratorTest.php
+++ b/test/Generator/ValueGeneratorTest.php
@@ -69,30 +69,28 @@ class ValueGeneratorTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider validConstantTypesProvider
      */
-    public function testValidConstantTypes($generator)
+    public function testValidConstantTypes($generator, $expectedOutput)
     {
         $propertyGenerator = new PropertyGenerator('FOO', $generator);
         $propertyGenerator->setConst(true);
-
-        $this->assertInternalType('string', $propertyGenerator->generate());
+        $this->assertSame($expectedOutput, $propertyGenerator->generate());
     }
 
     public function validConstantTypesProvider()
     {
         return [
-            [new PropertyValueGenerator([], PropertyValueGenerator::TYPE_ARRAY)],
-            [new PropertyValueGenerator([], PropertyValueGenerator::TYPE_ARRAY_LONG)],
-            [new PropertyValueGenerator([], PropertyValueGenerator::TYPE_ARRAY_SHORT)],
-            [new PropertyValueGenerator(true, PropertyValueGenerator::TYPE_BOOL)],
-            [new PropertyValueGenerator(true, PropertyValueGenerator::TYPE_BOOLEAN)],
-            [new PropertyValueGenerator(1, PropertyValueGenerator::TYPE_INT)],
-            [new PropertyValueGenerator(1, PropertyValueGenerator::TYPE_INTEGER)],
-            [new PropertyValueGenerator(0.1, PropertyValueGenerator::TYPE_DOUBLE)],
-            [new PropertyValueGenerator(0.1, PropertyValueGenerator::TYPE_FLOAT)],
-            [new PropertyValueGenerator('bar', PropertyValueGenerator::TYPE_STRING)],
-            [new PropertyValueGenerator(null, PropertyValueGenerator::TYPE_NULL)],
-            [new PropertyValueGenerator(null, PropertyValueGenerator::TYPE_NULL)],
-            [new PropertyValueGenerator('PHP_EOL', PropertyValueGenerator::TYPE_CONSTANT)],
+            [new PropertyValueGenerator([], PropertyValueGenerator::TYPE_ARRAY, ValueGenerator::OUTPUT_SINGLE_LINE), "    const FOO = array();"],
+            [new PropertyValueGenerator([], PropertyValueGenerator::TYPE_ARRAY_LONG, ValueGenerator::OUTPUT_SINGLE_LINE), "    const FOO = array();"],
+            [new PropertyValueGenerator([], PropertyValueGenerator::TYPE_ARRAY_SHORT, ValueGenerator::OUTPUT_SINGLE_LINE), "    const FOO = [];"],
+            [new PropertyValueGenerator(true, PropertyValueGenerator::TYPE_BOOL), "    const FOO = true;"],
+            [new PropertyValueGenerator(true, PropertyValueGenerator::TYPE_BOOLEAN), "    const FOO = true;"],
+            [new PropertyValueGenerator(1, PropertyValueGenerator::TYPE_INT), "    const FOO = 1;"],
+            [new PropertyValueGenerator(1, PropertyValueGenerator::TYPE_INTEGER), "    const FOO = 1;"],
+            [new PropertyValueGenerator(0.1, PropertyValueGenerator::TYPE_DOUBLE), "    const FOO = 0.1;"],
+            [new PropertyValueGenerator(0.1, PropertyValueGenerator::TYPE_FLOAT), "    const FOO = 0.1;"],
+            [new PropertyValueGenerator('bar', PropertyValueGenerator::TYPE_STRING), "    const FOO = 'bar';"],
+            [new PropertyValueGenerator(null, PropertyValueGenerator::TYPE_NULL), "    const FOO = null;"],
+            [new PropertyValueGenerator('PHP_EOL', PropertyValueGenerator::TYPE_CONSTANT), "    const FOO = PHP_EOL;"],
         ];
     }
 


### PR DESCRIPTION
```
const FOO = array('bar'=>'foobar');
```

This is a valid const, but can't be generated
