### PR TITLE
Fix generation of non-optional object parameters that can be null.

### DIFF
--- a/src/Generator/ParameterGenerator.php
+++ b/src/Generator/ParameterGenerator.php
@@ -63,7 +63,7 @@ class ParameterGenerator extends AbstractGenerator
 
         $param->setVariadic($variadic);
 
-        if (! $variadic && $reflectionParameter->isOptional()) {
+        if (! $variadic && ($reflectionParameter->isOptional() || $reflectionParameter->isDefaultValueAvailable())) {
             try {
                 $param->setDefaultValue($reflectionParameter->getDefaultValue());
             } catch (\ReflectionException $e) {

--- a/test/Generator/ParameterGeneratorTest.php
+++ b/test/Generator/ParameterGeneratorTest.php
@@ -98,6 +98,21 @@ class ParameterGeneratorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('\'foo\'', (string) $defaultValue);
     }
 
+    public function testFromReflectionGetDefaultValueNotOptional()
+    {
+        $reflectionClass = new \Zend\Code\Reflection\ClassReflection(
+            'ZendTest\Code\Generator\TestAsset\ParameterClass'
+        );
+        $method = $reflectionClass->getMethod('defaultObjectEqualsNullAndNotOptional');
+
+        $params = $method->getParameters();
+        $this->assertCount(2, $params);
+
+        $firstParameter = $codeGenParam = ParameterGenerator::fromReflection($params[0]);
+        $this->assertInstanceOf(ValueGenerator::class, $firstParameter->getDefaultValue());
+        $this->assertNull($firstParameter->getDefaultValue()->getSourceContent());
+    }
+
     public function testFromReflectionGetArrayHint()
     {
         $reflectionParameter = $this->getFirstReflectionParameter('fromArray');

--- a/test/Generator/TestAsset/ParameterClass.php
+++ b/test/Generator/TestAsset/ParameterClass.php
@@ -82,6 +82,11 @@ class ParameterClass
 
     }
 
+    public function defaultObjectEqualsNullAndNotOptional(\stdClass $a = null, $b)
+    {
+
+    }
+
     /**
      * @param int $integer
      */


### PR DESCRIPTION
Consider the following example:

```php
class Foo {
    public function doSomething(\stdClass $a = null, $b) {
    }
}
```

By generating a method from the ReflectionMethod of the given code above, the generated code did not consider the default value from $a. This has the effect, that one cannot pass null into that variable any more.

This PR fixes this. See also Ocramius/ProxyManager#337