### PR TITLE
Feature/docblock method chaining consistency

### DIFF
--- a/src/Annotation/AnnotationManager.php
+++ b/src/Annotation/AnnotationManager.php
@@ -37,7 +37,7 @@ class AnnotationManager implements EventManagerAwareInterface
      * Set the event manager instance
      *
      * @param  EventManagerInterface $events
-     * @return AnnotationManager
+     * @return AnnotationManager Provides a fluent interface
      */
     public function setEventManager(EventManagerInterface $events)
     {
@@ -70,7 +70,7 @@ class AnnotationManager implements EventManagerAwareInterface
      * Attach a parser to listen to the createAnnotation event
      *
      * @param  ParserInterface $parser
-     * @return AnnotationManager
+     * @return AnnotationManager Provides a fluent interface
      */
     public function attach(ParserInterface $parser)
     {

--- a/src/Annotation/Parser/DoctrineAnnotationParser.php
+++ b/src/Annotation/Parser/DoctrineAnnotationParser.php
@@ -48,7 +48,7 @@ class DoctrineAnnotationParser implements ParserInterface
      * Set the DocParser instance
      *
      * @param  DocParser $docParser
-     * @return DoctrineAnnotationParser
+     * @return DoctrineAnnotationParser Provides a fluent interface
      */
     public function setDocParser(DocParser $docParser)
     {
@@ -118,7 +118,7 @@ class DoctrineAnnotationParser implements ParserInterface
      * Specify an allowed annotation class
      *
      * @param  string $annotation
-     * @return DoctrineAnnotationParser
+     * @return DoctrineAnnotationParser Provides a fluent interface
      */
     public function registerAnnotation($annotation)
     {
@@ -132,7 +132,7 @@ class DoctrineAnnotationParser implements ParserInterface
      * @param  array|Traversable $annotations Array or traversable object of
      *         annotation class names
      * @throws Exception\InvalidArgumentException
-     * @return DoctrineAnnotationParser
+     * @return DoctrineAnnotationParser Provides a fluent interface
      */
     public function registerAnnotations($annotations)
     {

--- a/src/Annotation/Parser/GenericAnnotationParser.php
+++ b/src/Annotation/Parser/GenericAnnotationParser.php
@@ -118,7 +118,7 @@ class GenericAnnotationParser implements ParserInterface
      *
      * @param  array|Traversable $annotations
      * @throws Exception\InvalidArgumentException
-     * @return GenericAnnotationParser
+     * @return GenericAnnotationParser Provides a fluent interface
      */
     public function registerAnnotations($annotations)
     {
@@ -162,7 +162,7 @@ class GenericAnnotationParser implements ParserInterface
      * @param  string $alias
      * @param  string $class May be either a registered annotation name or another alias
      * @throws Exception\InvalidArgumentException
-     * @return GenericAnnotationParser
+     * @return GenericAnnotationParser Provides a fluent interface
      */
     public function setAlias($alias, $class)
     {

--- a/src/Generator/AbstractGenerator.php
+++ b/src/Generator/AbstractGenerator.php
@@ -45,7 +45,7 @@ abstract class AbstractGenerator implements GeneratorInterface
 
     /**
      * @param  bool $isSourceDirty
-     * @return AbstractGenerator
+     * @return AbstractGenerator Provides a fluent interface
      */
     public function setSourceDirty($isSourceDirty = true)
     {
@@ -63,7 +63,7 @@ abstract class AbstractGenerator implements GeneratorInterface
 
     /**
      * @param  string $indentation
-     * @return AbstractGenerator
+     * @return AbstractGenerator Provides a fluent interface
      */
     public function setIndentation($indentation)
     {
@@ -81,7 +81,7 @@ abstract class AbstractGenerator implements GeneratorInterface
 
     /**
      * @param  string $sourceContent
-     * @return AbstractGenerator
+     * @return AbstractGenerator Provides a fluent interface
      */
     public function setSourceContent($sourceContent)
     {
@@ -100,7 +100,7 @@ abstract class AbstractGenerator implements GeneratorInterface
     /**
      * @param  array|Traversable $options
      * @throws Exception\InvalidArgumentException
-     * @return AbstractGenerator
+     * @return AbstractGenerator Provides a fluent interface
      */
     public function setOptions($options)
     {

--- a/src/Generator/AbstractMemberGenerator.php
+++ b/src/Generator/AbstractMemberGenerator.php
@@ -48,7 +48,7 @@ abstract class AbstractMemberGenerator extends AbstractGenerator
 
     /**
      * @param  int|array $flags
-     * @return AbstractMemberGenerator
+     * @return AbstractMemberGenerator Provides a fluent interface
      */
     public function setFlags($flags)
     {
@@ -67,7 +67,7 @@ abstract class AbstractMemberGenerator extends AbstractGenerator
 
     /**
      * @param  int $flag
-     * @return AbstractMemberGenerator
+     * @return AbstractMemberGenerator Provides a fluent interface
      */
     public function addFlag($flag)
     {
@@ -77,7 +77,7 @@ abstract class AbstractMemberGenerator extends AbstractGenerator
 
     /**
      * @param  int $flag
-     * @return AbstractMemberGenerator
+     * @return AbstractMemberGenerator Provides a fluent interface
      */
     public function removeFlag($flag)
     {
@@ -87,7 +87,7 @@ abstract class AbstractMemberGenerator extends AbstractGenerator
 
     /**
      * @param  bool $isAbstract
-     * @return AbstractMemberGenerator
+     * @return AbstractMemberGenerator Provides a fluent interface
      */
     public function setAbstract($isAbstract)
     {
@@ -104,7 +104,7 @@ abstract class AbstractMemberGenerator extends AbstractGenerator
 
     /**
      * @param  bool $isInterface
-     * @return AbstractMemberGenerator
+     * @return AbstractMemberGenerator Provides a fluent interface
      */
     public function setInterface($isInterface)
     {
@@ -155,7 +155,7 @@ abstract class AbstractMemberGenerator extends AbstractGenerator
 
     /**
      * @param  string $visibility
-     * @return AbstractMemberGenerator
+     * @return AbstractMemberGenerator Provides a fluent interface
      */
     public function setVisibility($visibility)
     {
@@ -194,7 +194,7 @@ abstract class AbstractMemberGenerator extends AbstractGenerator
 
     /**
      * @param  string $name
-     * @return AbstractMemberGenerator
+     * @return AbstractMemberGenerator Provides a fluent interface
      */
     public function setName($name)
     {
@@ -213,7 +213,7 @@ abstract class AbstractMemberGenerator extends AbstractGenerator
     /**
      * @param  DocBlockGenerator|string $docBlock
      * @throws Exception\InvalidArgumentException
-     * @return AbstractMemberGenerator
+     * @return AbstractMemberGenerator Provides a fluent interface
      */
     public function setDocBlock($docBlock)
     {

--- a/src/Generator/BodyGenerator.php
+++ b/src/Generator/BodyGenerator.php
@@ -18,7 +18,7 @@ class BodyGenerator extends AbstractGenerator
 
     /**
      * @param  string $content
-     * @return BodyGenerator
+     * @return BodyGenerator Provides a fluent interface
      */
     public function setContent($content)
     {

--- a/src/Generator/ClassGenerator.php
+++ b/src/Generator/ClassGenerator.php
@@ -262,7 +262,7 @@ class ClassGenerator extends AbstractGenerator
 
     /**
      * @param  string $name
-     * @return self
+     * @@return ClassGenerator Provides a fluent interface
      */
     public function setName($name)
     {
@@ -286,7 +286,7 @@ class ClassGenerator extends AbstractGenerator
 
     /**
      * @param  string $namespaceName
-     * @return self
+     * @return ClassGenerator Provides a fluent interface
      */
     public function setNamespaceName($namespaceName)
     {
@@ -304,7 +304,7 @@ class ClassGenerator extends AbstractGenerator
 
     /**
      * @param  FileGenerator $fileGenerator
-     * @return self
+     * @return ClassGenerator Provides a fluent interface
      */
     public function setContainingFileGenerator(FileGenerator $fileGenerator)
     {
@@ -322,7 +322,7 @@ class ClassGenerator extends AbstractGenerator
 
     /**
      * @param  DocBlockGenerator $docBlock
-     * @return self
+     * @return ClassGenerator Provides a fluent interface
      */
     public function setDocBlock(DocBlockGenerator $docBlock)
     {
@@ -340,7 +340,7 @@ class ClassGenerator extends AbstractGenerator
 
     /**
      * @param  array|string $flags
-     * @return self
+     * @return ClassGenerator Provides a fluent interface
      */
     public function setFlags($flags)
     {
@@ -359,7 +359,7 @@ class ClassGenerator extends AbstractGenerator
 
     /**
      * @param  string $flag
-     * @return self
+     * @return ClassGenerator Provides a fluent interface
      */
     public function addFlag($flag)
     {
@@ -369,7 +369,7 @@ class ClassGenerator extends AbstractGenerator
 
     /**
      * @param  string $flag
-     * @return self
+     * @return ClassGenerator Provides a fluent interface
      */
     public function removeFlag($flag)
     {
@@ -379,7 +379,7 @@ class ClassGenerator extends AbstractGenerator
 
     /**
      * @param  bool $isAbstract
-     * @return self
+     * @return ClassGenerator Provides a fluent interface
      */
     public function setAbstract($isAbstract)
     {
@@ -413,7 +413,7 @@ class ClassGenerator extends AbstractGenerator
 
     /**
      * @param  string $extendedClass
-     * @return self
+     * @return ClassGenerator Provides a fluent interface
      */
     public function setExtendedClass($extendedClass)
     {
@@ -438,7 +438,7 @@ class ClassGenerator extends AbstractGenerator
     }
 
     /**
-     * @return self
+     * @return ClassGenerator Provides a fluent interface
      */
     public function removeExtentedClass()
     {
@@ -448,7 +448,7 @@ class ClassGenerator extends AbstractGenerator
 
     /**
      * @param  array $implementedInterfaces
-     * @return self
+     * @return ClassGenerator Provides a fluent interface
      */
     public function setImplementedInterfaces(array $implementedInterfaces)
     {
@@ -480,7 +480,7 @@ class ClassGenerator extends AbstractGenerator
 
     /**
      * @param $implementedInterface
-     * @return self
+     * @return ClassGenerator Provides a fluent interface
      */
     public function removeImplementedInterface($implementedInterface)
     {
@@ -512,7 +512,7 @@ class ClassGenerator extends AbstractGenerator
 
     /**
      * @param  string $constantName
-     * @return self
+     * @return ClassGenerator Provides a fluent interface
      */
     public function removeConstant($constantName)
     {
@@ -535,7 +535,7 @@ class ClassGenerator extends AbstractGenerator
      *
      * @param  PropertyGenerator           $constant
      * @throws Exception\InvalidArgumentException
-     * @return self
+     * @return ClassGenerator Provides a fluent interface
      */
     public function addConstantFromGenerator(PropertyGenerator $constant)
     {
@@ -608,7 +608,7 @@ class ClassGenerator extends AbstractGenerator
 
     /**
      * @param  array $properties
-     * @return self
+     * @return ClassGenerator Provides a fluent interface
      */
     public function addProperties(array $properties)
     {
@@ -634,7 +634,7 @@ class ClassGenerator extends AbstractGenerator
      * @param  string|array $defaultValue
      * @param  int $flags
      * @throws Exception\InvalidArgumentException
-     * @return self
+     * @return ClassGenerator Provides a fluent interface
      */
     public function addProperty($name, $defaultValue = null, $flags = PropertyGenerator::FLAG_PUBLIC)
     {
@@ -660,7 +660,7 @@ class ClassGenerator extends AbstractGenerator
      *
      * @param  PropertyGenerator           $property
      * @throws Exception\InvalidArgumentException
-     * @return self
+     * @return ClassGenerator Provides a fluent interface
      */
     public function addPropertyFromGenerator(PropertyGenerator $property)
     {
@@ -711,7 +711,7 @@ class ClassGenerator extends AbstractGenerator
      *
      * @param  string $use
      * @param  string|null $useAlias
-     * @return self
+     * @return ClassGenerator Provides a fluent interface
      */
     public function addUse($use, $useAlias = null)
     {
@@ -721,7 +721,7 @@ class ClassGenerator extends AbstractGenerator
 
     /**
      * @param string $use
-     * @return self
+     * @return bool
      */
     public function hasUse($use)
     {
@@ -730,7 +730,7 @@ class ClassGenerator extends AbstractGenerator
 
     /**
      * @param  string $use
-     * @return self
+     * @return ClassGenerator Provides a fluent interface
      */
     public function removeUse($use)
     {
@@ -749,7 +749,7 @@ class ClassGenerator extends AbstractGenerator
 
     /**
      * @param $use
-     * @return self
+     * @return ClassGenerator Provides a fluent interface
      */
     public function removeUseAlias($use)
     {
@@ -770,7 +770,7 @@ class ClassGenerator extends AbstractGenerator
 
     /**
      * @param  string $propertyName
-     * @return self
+     * @return ClassGenerator Provides a fluent interface
      */
     public function removeProperty($propertyName)
     {
@@ -790,7 +790,7 @@ class ClassGenerator extends AbstractGenerator
 
     /**
      * @param  array $methods
-     * @return self
+     * @return ClassGenerator Provides a fluent interface
      */
     public function addMethods(array $methods)
     {
@@ -818,7 +818,7 @@ class ClassGenerator extends AbstractGenerator
      * @param  string $body
      * @param  string $docBlock
      * @throws Exception\InvalidArgumentException
-     * @return self
+     * @return ClassGenerator Provides a fluent interface
      */
     public function addMethod(
         $name,
@@ -843,7 +843,7 @@ class ClassGenerator extends AbstractGenerator
      *
      * @param  MethodGenerator                    $method
      * @throws Exception\InvalidArgumentException
-     * @return self
+     * @return ClassGenerator Provides a fluent interface
      */
     public function addMethodFromGenerator(MethodGenerator $method)
     {
@@ -879,7 +879,7 @@ class ClassGenerator extends AbstractGenerator
 
     /**
      * @param  string $methodName
-     * @return self
+     * @return ClassGenerator Provides a fluent interface
      */
     public function removeMethod($methodName)
     {

--- a/src/Generator/DocBlock/Tag/AbstractTypeableTag.php
+++ b/src/Generator/DocBlock/Tag/AbstractTypeableTag.php
@@ -45,7 +45,7 @@ abstract class AbstractTypeableTag extends AbstractGenerator
 
     /**
      * @param string $description
-     * @return ReturnTag
+     * @return AbstractTypeableTag Provides a fluent interface
      */
     public function setDescription($description)
     {
@@ -66,7 +66,7 @@ abstract class AbstractTypeableTag extends AbstractGenerator
      * e.g. array('int', 'null') or "int|null"
      *
      * @param array|string $types
-     * @return ReturnTag
+     * @return AbstractTypeableTag Provides a fluent interface
      */
     public function setTypes($types)
     {

--- a/src/Generator/DocBlock/Tag/AuthorTag.php
+++ b/src/Generator/DocBlock/Tag/AuthorTag.php
@@ -62,7 +62,7 @@ class AuthorTag extends AbstractGenerator implements TagInterface
 
     /**
      * @param string $authorEmail
-     * @return AuthorTag
+     * @return AuthorTag Provides a fluent interface
      */
     public function setAuthorEmail($authorEmail)
     {
@@ -80,7 +80,7 @@ class AuthorTag extends AbstractGenerator implements TagInterface
 
     /**
      * @param string $authorName
-     * @return AuthorTag
+     * @return AuthorTag Provides a fluent interface
      */
     public function setAuthorName($authorName)
     {

--- a/src/Generator/DocBlock/Tag/GenericTag.php
+++ b/src/Generator/DocBlock/Tag/GenericTag.php
@@ -41,7 +41,7 @@ class GenericTag extends AbstractGenerator implements TagInterface, PrototypeGen
 
     /**
      * @param  string $name
-     * @return GenericTag
+     * @return GenericTag Provides a fluent interface
      */
     public function setName($name)
     {
@@ -59,7 +59,7 @@ class GenericTag extends AbstractGenerator implements TagInterface, PrototypeGen
 
     /**
      * @param string $content
-     * @return GenericTag
+     * @return GenericTag Provides a fluent interface
      */
     public function setContent($content)
     {

--- a/src/Generator/DocBlock/Tag/LicenseTag.php
+++ b/src/Generator/DocBlock/Tag/LicenseTag.php
@@ -62,7 +62,7 @@ class LicenseTag extends AbstractGenerator implements TagInterface
 
     /**
      * @param string $url
-     * @return LicenseTag
+     * @return LicenseTag Provides a fluent interface
      */
     public function setUrl($url)
     {
@@ -80,7 +80,7 @@ class LicenseTag extends AbstractGenerator implements TagInterface
 
     /**
      * @param  string $name
-     * @return LicenseTag
+     * @return LicenseTag Provides a fluent interface
      */
     public function setLicenseName($name)
     {

--- a/src/Generator/DocBlock/Tag/MethodTag.php
+++ b/src/Generator/DocBlock/Tag/MethodTag.php
@@ -48,7 +48,7 @@ class MethodTag extends AbstractTypeableTag implements TagInterface
 
     /**
      * @param boolean $isStatic
-     * @return MethodTag
+     * @return MethodTag Provides a fluent interface
      */
     public function setIsStatic($isStatic)
     {
@@ -66,7 +66,7 @@ class MethodTag extends AbstractTypeableTag implements TagInterface
 
     /**
      * @param string $methodName
-     * @return MethodTag
+     * @return MethodTag Provides a fluent interface
      */
     public function setMethodName($methodName)
     {

--- a/src/Generator/DocBlock/Tag/ParamTag.php
+++ b/src/Generator/DocBlock/Tag/ParamTag.php
@@ -55,7 +55,7 @@ class ParamTag extends AbstractTypeableTag implements TagInterface
 
     /**
      * @param string $variableName
-     * @return ParamTag
+     * @return ParamTag Provides a fluent interface
      */
     public function setVariableName($variableName)
     {

--- a/src/Generator/DocBlock/Tag/PropertyTag.php
+++ b/src/Generator/DocBlock/Tag/PropertyTag.php
@@ -40,7 +40,7 @@ class PropertyTag extends AbstractTypeableTag implements TagInterface
 
     /**
      * @param string $propertyName
-     * @return self
+     * @return PropertyTag Provides a fluent interface
      */
     public function setPropertyName($propertyName)
     {

--- a/src/Generator/DocBlockGenerator.php
+++ b/src/Generator/DocBlockGenerator.php
@@ -128,7 +128,7 @@ class DocBlockGenerator extends AbstractGenerator
 
     /**
      * @param  string $shortDescription
-     * @return DocBlockGenerator
+     * @return DocBlockGenerator Provides a fluent interface
      */
     public function setShortDescription($shortDescription)
     {
@@ -146,7 +146,7 @@ class DocBlockGenerator extends AbstractGenerator
 
     /**
      * @param  string $longDescription
-     * @return DocBlockGenerator
+     * @return DocBlockGenerator Provides a fluent interface
      */
     public function setLongDescription($longDescription)
     {
@@ -164,7 +164,7 @@ class DocBlockGenerator extends AbstractGenerator
 
     /**
      * @param  array $tags
-     * @return DocBlockGenerator
+     * @return DocBlockGenerator Provides a fluent interface
      */
     public function setTags(array $tags)
     {
@@ -178,7 +178,7 @@ class DocBlockGenerator extends AbstractGenerator
     /**
      * @param array|TagInterface $tag
      * @throws Exception\InvalidArgumentException
-     * @return DocBlockGenerator
+     * @return DocBlockGenerator Provides a fluent interface
      */
     public function setTag($tag)
     {
@@ -209,7 +209,7 @@ class DocBlockGenerator extends AbstractGenerator
 
     /**
      * @param bool $value
-     * @return DocBlockGenerator
+     * @return DocBlockGenerator Provides a fluent interface
      */
     public function setWordWrap($value)
     {

--- a/src/Generator/FileGenerator.php
+++ b/src/Generator/FileGenerator.php
@@ -158,7 +158,7 @@ class FileGenerator extends AbstractGenerator
     /**
      * @param  DocBlockGenerator|array|string $docBlock
      * @throws Exception\InvalidArgumentException
-     * @return FileGenerator
+     * @return FileGenerator Provides a fluent interface
      */
     public function setDocBlock($docBlock)
     {
@@ -190,7 +190,7 @@ class FileGenerator extends AbstractGenerator
 
     /**
      * @param  array $requiredFiles
-     * @return FileGenerator
+     * @return FileGenerator Provides a fluent interface
      */
     public function setRequiredFiles(array $requiredFiles)
     {
@@ -216,7 +216,7 @@ class FileGenerator extends AbstractGenerator
 
     /**
      * @param  string $namespace
-     * @return FileGenerator
+     * @return FileGenerator Provides a fluent interface
      */
     public function setNamespace($namespace)
     {
@@ -254,7 +254,7 @@ class FileGenerator extends AbstractGenerator
 
     /**
      * @param  array $uses
-     * @return FileGenerator
+     * @return FileGenerator Provides a fluent interface
      */
     public function setUses(array $uses)
     {
@@ -277,7 +277,7 @@ class FileGenerator extends AbstractGenerator
     /**
      * @param  string $use
      * @param  null|string $as
-     * @return FileGenerator
+     * @return FileGenerator Provides a fluent interface
      */
     public function setUse($use, $as = null)
     {
@@ -289,7 +289,7 @@ class FileGenerator extends AbstractGenerator
 
     /**
      * @param  array $classes
-     * @return FileGenerator
+     * @return FileGenerator Provides a fluent interface
      */
     public function setClasses(array $classes)
     {
@@ -318,7 +318,7 @@ class FileGenerator extends AbstractGenerator
     /**
      * @param  array|string|ClassGenerator $class
      * @throws Exception\InvalidArgumentException
-     * @return FileGenerator
+     * @return FileGenerator Provides a fluent interface
      */
     public function setClass($class)
     {
@@ -343,7 +343,7 @@ class FileGenerator extends AbstractGenerator
 
     /**
      * @param  string $filename
-     * @return FileGenerator
+     * @return FileGenerator Provides a fluent interface
      */
     public function setFilename($filename)
     {
@@ -369,7 +369,7 @@ class FileGenerator extends AbstractGenerator
 
     /**
      * @param  string $body
-     * @return FileGenerator
+     * @return FileGenerator Provides a fluent interface
      */
     public function setBody($body)
     {
@@ -554,7 +554,7 @@ class FileGenerator extends AbstractGenerator
     }
 
     /**
-     * @return FileGenerator
+     * @return FileGenerator Provides a fluent interface
      * @throws Exception\RuntimeException
      */
     public function write()

--- a/src/Generator/MethodGenerator.php
+++ b/src/Generator/MethodGenerator.php
@@ -208,7 +208,7 @@ class MethodGenerator extends AbstractMemberGenerator
 
     /**
      * @param  array $parameters
-     * @return MethodGenerator
+     * @return MethodGenerator Provides a fluent interface
      */
     public function setParameters(array $parameters)
     {
@@ -222,7 +222,7 @@ class MethodGenerator extends AbstractMemberGenerator
     /**
      * @param  ParameterGenerator|array|string $parameter
      * @throws Exception\InvalidArgumentException
-     * @return MethodGenerator
+     * @return MethodGenerator Provides a fluent interface
      */
     public function setParameter($parameter)
     {
@@ -257,7 +257,7 @@ class MethodGenerator extends AbstractMemberGenerator
 
     /**
      * @param  string $body
-     * @return MethodGenerator
+     * @return MethodGenerator Provides a fluent interface
      */
     public function setBody($body)
     {
@@ -276,7 +276,7 @@ class MethodGenerator extends AbstractMemberGenerator
     /**
      * @param string|null
      *
-     * @return MethodGenerator
+     * @return MethodGenerator Provides a fluent interface
      */
     public function setReturnType($returnType = null)
     {
@@ -298,7 +298,7 @@ class MethodGenerator extends AbstractMemberGenerator
     /**
      * @param bool $returnsReference
      *
-     * @return MethodGenerator
+     * @return MethodGenerator Provides a fluent interface
      */
     public function setReturnsReference($returnsReference)
     {

--- a/src/Generator/ParameterGenerator.php
+++ b/src/Generator/ParameterGenerator.php
@@ -165,7 +165,7 @@ class ParameterGenerator extends AbstractGenerator
 
     /**
      * @param  string $type
-     * @return ParameterGenerator
+     * @return ParameterGenerator Provides a fluent interface
      */
     public function setType($type)
     {
@@ -186,7 +186,7 @@ class ParameterGenerator extends AbstractGenerator
 
     /**
      * @param  string $name
-     * @return ParameterGenerator
+     * @return ParameterGenerator Provides a fluent interface
      */
     public function setName($name)
     {
@@ -208,7 +208,7 @@ class ParameterGenerator extends AbstractGenerator
      * Certain variables are difficult to express
      *
      * @param  null|bool|string|int|float|array|ValueGenerator $defaultValue
-     * @return ParameterGenerator
+     * @return ParameterGenerator Provides a fluent interface
      */
     public function setDefaultValue($defaultValue)
     {
@@ -230,7 +230,7 @@ class ParameterGenerator extends AbstractGenerator
 
     /**
      * @param  int $position
-     * @return ParameterGenerator
+     * @return ParameterGenerator Provides a fluent interface
      */
     public function setPosition($position)
     {
@@ -256,7 +256,7 @@ class ParameterGenerator extends AbstractGenerator
 
     /**
      * @param  bool $passedByReference
-     * @return ParameterGenerator
+     * @return ParameterGenerator Provides a fluent interface
      */
     public function setPassedByReference($passedByReference)
     {
@@ -267,7 +267,7 @@ class ParameterGenerator extends AbstractGenerator
     /**
      * @param bool $variadic
      *
-     * @return ParameterGenerator
+     * @return ParameterGenerator Provides a fluent interface
      */
     public function setVariadic($variadic)
     {
@@ -387,8 +387,6 @@ class ParameterGenerator extends AbstractGenerator
     }
 
     /**
-     * @param string|null $type
-     *
      * @return string
      */
     private function generateTypeHint()

--- a/src/Generator/PropertyGenerator.php
+++ b/src/Generator/PropertyGenerator.php
@@ -139,7 +139,7 @@ class PropertyGenerator extends AbstractMemberGenerator
 
     /**
      * @param  bool $const
-     * @return PropertyGenerator
+     * @return PropertyGenerator Provides a fluent interface
      */
     public function setConst($const)
     {
@@ -166,7 +166,7 @@ class PropertyGenerator extends AbstractMemberGenerator
      * @param string                       $defaultValueType
      * @param string                       $defaultValueOutputMode
      *
-     * @return PropertyGenerator
+     * @return PropertyGenerator Provides a fluent interface
      */
     public function setDefaultValue(
         $defaultValue,

--- a/src/Generator/TraitGenerator.php
+++ b/src/Generator/TraitGenerator.php
@@ -110,7 +110,7 @@ class TraitGenerator extends ClassGenerator
 
     /**
      * @param  array|string $flags
-     * @return self
+     * @return TraitGenerator Provides a fluent interface
      */
     public function setFlags($flags)
     {
@@ -119,7 +119,7 @@ class TraitGenerator extends ClassGenerator
 
     /**
      * @param  string $flag
-     * @return self
+     * @return TraitGenerator Provides a fluent interface
      */
     public function addFlag($flag)
     {
@@ -128,7 +128,7 @@ class TraitGenerator extends ClassGenerator
 
     /**
      * @param  string $flag
-     * @return self
+     * @return TraitGenerator Provides a fluent interface
      */
     public function removeFlag($flag)
     {
@@ -137,7 +137,7 @@ class TraitGenerator extends ClassGenerator
 
     /**
      * @param  bool $isFinal
-     * @return self
+     * @return TraitGenerator Provides a fluent interface
      */
     public function setFinal($isFinal)
     {
@@ -146,7 +146,7 @@ class TraitGenerator extends ClassGenerator
 
     /**
      * @param  string $extendedClass
-     * @return self
+     * @return TraitGenerator Provides a fluent interface
      */
     public function setExtendedClass($extendedClass)
     {
@@ -155,7 +155,7 @@ class TraitGenerator extends ClassGenerator
 
     /**
      * @param  array $implementedInterfaces
-     * @return self
+     * @return TraitGenerator Provides a fluent interface
      */
     public function setImplementedInterfaces(array $implementedInterfaces)
     {
@@ -164,7 +164,7 @@ class TraitGenerator extends ClassGenerator
 
     /**
      * @param  bool $isAbstract
-     * @return self
+     * @return TraitGenerator Provides a fluent interface
      */
     public function setAbstract($isAbstract)
     {

--- a/src/Generator/TraitUsageGenerator.php
+++ b/src/Generator/TraitUsageGenerator.php
@@ -100,7 +100,7 @@ class TraitUsageGenerator extends AbstractGenerator
 
     /**
      * @param $use
-     * @return TraitUsageGenerator
+     * @return TraitUsageGenerator Provides a fluent interface
      */
     public function removeUse($use)
     {
@@ -116,7 +116,7 @@ class TraitUsageGenerator extends AbstractGenerator
 
     /**
      * @param $use
-     * @return TraitUsageGenerator
+     * @return TraitUsageGenerator Provides a fluent interface
      */
     public function removeUseAlias($use)
     {

--- a/src/Generator/TraitUsageInterface.php
+++ b/src/Generator/TraitUsageInterface.php
@@ -50,7 +50,7 @@ interface TraitUsageInterface
      * Add multiple traits.  Trait can be an array of trait names or array of trait
      * configurations
      *
-     * @param array $traitName Array of string names or configurations (@see addTrait)
+     * @param array $traits Array of string names or configurations (@see addTrait)
      * @return self
      */
     public function addTraits(array $traits);
@@ -58,7 +58,7 @@ interface TraitUsageInterface
     /**
      * Check to see if the class has a trait defined
      *
-     * @param strint $traitName
+     * @param string $traitName
      * @return bool
      */
     public function hasTrait($traitName);
@@ -95,7 +95,7 @@ interface TraitUsageInterface
      *
      * @param mixed $method String or Array
      * @param string $alias
-     * @param int $visiblity
+     * @param null|int $visibility
      */
     public function addTraitAlias($method, $alias, $visibility = null);
 
@@ -123,7 +123,7 @@ interface TraitUsageInterface
      * Option 2: Array of strings of traits to replace
 
      * @param mixed $method
-     * @param mixed $traitToReplace
+     * @param mixed $traitsToReplace
      */
     public function addTraitOverride($method, $traitsToReplace);
 
@@ -144,9 +144,9 @@ interface TraitUsageInterface
      * Option 1: String of trait to replace
      * Option 2: Array of strings of traits to replace
      *
-     * @param $traitAndMethod
+     * @param $method
      * @param null $overridesToRemove
-     * @return $this
+     * @return TraitUsageInterface
      */
     public function removeTraitOverride($method, $overridesToRemove = null);
 

--- a/src/Generator/ValueGenerator.php
+++ b/src/Generator/ValueGenerator.php
@@ -126,7 +126,7 @@ class ValueGenerator extends AbstractGenerator
      *
      * @param string $constant
      *
-     * @return $this
+     * @return ValueGenerator Provides a fluent interface
      */
     public function addConstant($constant)
     {
@@ -193,7 +193,7 @@ class ValueGenerator extends AbstractGenerator
 
     /**
      * @param  mixed $value
-     * @return ValueGenerator
+     * @return ValueGenerator Provides a fluent interface
      */
     public function setValue($value)
     {
@@ -211,7 +211,7 @@ class ValueGenerator extends AbstractGenerator
 
     /**
      * @param  string $type
-     * @return ValueGenerator
+     * @return ValueGenerator Provides a fluent interface
      */
     public function setType($type)
     {
@@ -229,7 +229,7 @@ class ValueGenerator extends AbstractGenerator
 
     /**
      * @param  int $arrayDepth
-     * @return ValueGenerator
+     * @return ValueGenerator Provides a fluent interface
      */
     public function setArrayDepth($arrayDepth)
     {
@@ -446,7 +446,7 @@ class ValueGenerator extends AbstractGenerator
 
     /**
      * @param  string $outputMode
-     * @return ValueGenerator
+     * @return ValueGenerator Provides a fluent interface
      */
     public function setOutputMode($outputMode)
     {

--- a/src/NameInformation.php
+++ b/src/NameInformation.php
@@ -37,7 +37,7 @@ class NameInformation
 
     /**
      * @param  string $namespace
-     * @return NameInformation
+     * @return NameInformation Provides a fluent interface
      */
     public function setNamespace($namespace)
     {
@@ -63,7 +63,7 @@ class NameInformation
 
     /**
      * @param  array $uses
-     * @return NameInformation
+     * @return NameInformation Provides a fluent interface
      */
     public function setUses(array $uses)
     {
@@ -75,7 +75,7 @@ class NameInformation
 
     /**
      * @param  array $uses
-     * @return NameInformation
+     * @return NameInformation Provides a fluent interface
      */
     public function addUses(array $uses)
     {

--- a/src/Scanner/MethodScanner.php
+++ b/src/Scanner/MethodScanner.php
@@ -112,7 +112,7 @@ class MethodScanner implements ScannerInterface
 
     /**
      * @param  string $class
-     * @return MethodScanner
+     * @return MethodScanner Provides a fluent interface
      */
     public function setClass($class)
     {
@@ -122,7 +122,7 @@ class MethodScanner implements ScannerInterface
 
     /**
      * @param  ClassScanner  $scannerClass
-     * @return MethodScanner
+     * @return ClassScanner Provides a fluent interface
      */
     public function setScannerClass(ClassScanner $scannerClass)
     {
@@ -131,7 +131,7 @@ class MethodScanner implements ScannerInterface
     }
 
     /**
-     * @return MethodScanner
+     * @return ClassScanner Provides a fluent interface
      */
     public function getClassScanner()
     {
@@ -256,7 +256,7 @@ class MethodScanner implements ScannerInterface
      * support traits.
      *
      * @param $name
-     * @return self
+     * @return MethodScanner Provides a fluent interface
      */
     public function setName($name)
     {
@@ -269,7 +269,7 @@ class MethodScanner implements ScannerInterface
      * Needed to support traits
      *
      * @param $visibility   T_PUBLIC | T_PRIVATE | T_PROTECTED
-     * @return self
+     * @return MethodScanner Provides a fluent interface
      * @throws \Zend\Code\Exception
      */
     public function setVisibility($visibility)

--- a/test/Reflection/TestAsset/TestTraitClass2.php
+++ b/test/Reflection/TestAsset/TestTraitClass2.php
@@ -16,8 +16,8 @@ trait TestTrait
 	}
 
 	/**
-	* @param bool $autoFetchingAllowed
-	* @return Model_AbstractModel
+	* @param bool $dummy
+	* @return TestTrait Provides a fluent interface
 	*/
 	public function setDummy($dummy)
 	{


### PR DESCRIPTION
As discussed in [fluent interface return type vs return self #7193](https://github.com/zendframework/zendframework/issues/7193), this changes remove occurrences of class names and self keyword from the DocBlocks
