### PR TITLE
Don't call isInternalPhpType() twice in TypeGenerator

### DIFF
--- a/src/Generator/TypeGenerator.php
+++ b/src/Generator/TypeGenerator.php
@@ -78,7 +78,7 @@ final class TypeGenerator implements GeneratorInterface
 
         $instance->type              = $trimmedType;
         $instance->nullable          = $nullable;
-        $instance->isInternalPhpType = self::isInternalPhpType($trimmedType);
+        $instance->isInternalPhpType = $isInternalPhpType;
 
         return $instance;
     }


### PR DESCRIPTION
It is currently called twice with the same argument.