### PR TITLE
Bumped PHP to 7.1 and updated PHPUnit to ^6.2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,9 @@ cache:
 
 env:
   global:
-    - COMPOSER_ARGS="--no-interaction --ignore-platform-reqs"
+    - COMPOSER_ARGS="--no-interaction"
+    - COVERAGE_DEPS="satooshi/php-coveralls"
+    - LEGACY_DEPS="phpunit/phpunit"
     - TESTS_ZEND_CODE_ANNOTATION_DOCTRINE_SUPPORT=true
     - SITE_URL="https://zendframework.github.io/zend-code"
     - GH_USER_NAME="Matthew Weier O'Phinney"
@@ -77,11 +79,13 @@ before_install:
   - if [[ $TRAVIS_PHP_VERSION != "hhvm" && $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || true ; fi
 
 install:
+  - travis_retry composer install $COMPOSER_ARGS --ignore-platform-reqs
+  - if [[ $TRAVIS_PHP_VERSION =~ ^5.6 ]]; then travis_retry composer update $COMPOSER_ARGS --with-dependencies $LEGACY_DEPS ; fi
   - if [[ $DEPS == 'latest' ]]; then travis_retry composer update $COMPOSER_ARGS ; fi
-  - if [[ $DEPS == 'lowest' ]]; then travis_retry composer update --prefer-lowest --prefer-stable $COMPOSER_ARGS ; fi
-  - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry composer require --dev $COMPOSER_ARGS satooshi/php-coveralls:^1.0 ; fi
-  - travis_retry composer install $COMPOSER_ARGS
-  - composer show
+  - if [[ $DEPS == 'lowest' ]]; then travis_retry composer update $COMPOSER_ARGS --prefer-lowest --prefer-stable ; fi
+  - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry composer require --dev $COMPOSER_ARGS $COVERAGE_DEPS ; fi
+  - stty cols 120
+  - COLUMNS=120 composer show
 
 script:
   - if [[ $TEST_COVERAGE == 'true' ]]; then composer test-coverage ; else composer test ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,17 +39,17 @@ matrix:
     - php: 7.1
       env:
         - DEPS=latest
-    - php: hhvm
+    - php: nightly
       env:
         - DEPS=lowest
-    - php: hhvm
+    - php: nightly
       env:
         - DEPS=locked
-    - php: hhvm
+    - php: nightly
       env:
         - DEPS=latest
   allow_failures:
-    - php: hhvm
+    - php: nightly
 
 notifications:
   irc: "irc.freenode.org#zftalk.dev"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ env:
   global:
     - COMPOSER_ARGS="--no-interaction"
     - COVERAGE_DEPS="satooshi/php-coveralls"
-    - LEGACY_DEPS="phpunit/phpunit"
     - TESTS_ZEND_CODE_ANNOTATION_DOCTRINE_SUPPORT=true
     - SITE_URL="https://zendframework.github.io/zend-code"
     - GH_USER_NAME="Matthew Weier O'Phinney"
@@ -27,34 +26,16 @@ env:
 
 matrix:
   include:
-    - php: 5.6
+    - php: 7.1
       env:
         - DEPS=lowest
-    - php: 5.6
+    - php: 7.1
       env:
         - DEPS=locked
         - DEPLOY_DOCS="$(if [[ $TRAVIS_BRANCH == 'master' && $TRAVIS_PULL_REQUEST == 'false' ]]; then echo -n 'true' ; else echo -n 'false' ; fi)"
         - PATH="$HOME/.local/bin:$PATH"
         - TEST_COVERAGE=true
-    - php: 5.6
-      env:
-        - DEPS=latest
-    - php: 7
-      env:
-        - DEPS=lowest
-    - php: 7
-      env:
-        - DEPS=locked
         - CHECK_CS=true
-    - php: 7
-      env:
-        - DEPS=latest
-    - php: 7.1
-      env:
-        - DEPS=lowest
-    - php: 7.1
-      env:
-        - DEPS=locked
     - php: 7.1
       env:
         - DEPS=latest
@@ -79,11 +60,10 @@ before_install:
   - if [[ $TRAVIS_PHP_VERSION != "hhvm" && $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || true ; fi
 
 install:
-  - travis_retry composer install $COMPOSER_ARGS --ignore-platform-reqs
-  - if [[ $TRAVIS_PHP_VERSION =~ ^5.6 ]]; then travis_retry composer update $COMPOSER_ARGS --with-dependencies $LEGACY_DEPS ; fi
   - if [[ $DEPS == 'latest' ]]; then travis_retry composer update $COMPOSER_ARGS ; fi
   - if [[ $DEPS == 'lowest' ]]; then travis_retry composer update $COMPOSER_ARGS --prefer-lowest --prefer-stable ; fi
   - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry composer require --dev $COMPOSER_ARGS $COVERAGE_DEPS ; fi
+  - travis_retry composer install $COMPOSER_ARGS
   - stty cols 120
   - COLUMNS=120 composer show
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "doctrine/annotations": "~1.0",
         "zendframework/zend-stdlib": "^2.7 || ^3.0",
         "squizlabs/php_codesniffer": "^2.5",
-        "phpunit/PHPUnit": "^4.8.21"
+        "phpunit/phpunit": "^6.2.2 || ^5.7.21"
     },
     "suggest": {
         "doctrine/annotations": "Doctrine\\Common\\Annotations >=1.0 for annotation features",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     },
     "require": {
-        "php": "^5.6 || 7.0.0 - 7.0.4 || ^7.0.6",
+        "php": "^7.1",
         "zendframework/zend-eventmanager": "^2.6 || ^3.0"
     },
     "require-dev": {
@@ -21,7 +21,7 @@
         "doctrine/annotations": "~1.0",
         "zendframework/zend-stdlib": "^2.7 || ^3.0",
         "squizlabs/php_codesniffer": "^2.5",
-        "phpunit/phpunit": "^6.2.2 || ^5.7.21"
+        "phpunit/phpunit": "^6.2.2"
     },
     "suggest": {
         "doctrine/annotations": "Doctrine\\Common\\Annotations >=1.0 for annotation features",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "42e54a17b1d6afc8d4d7cbd282235e2a",
+    "content-hash": "2d329d458f0777ea887a1a01a7239c24",
     "packages": [
         {
             "name": "zendframework/zend-eventmanager",
@@ -1763,7 +1763,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^5.6 || 7.0.0 - 7.0.4 || ^7.0.6"
+        "php": "^7.1"
     },
     "platform-dev": {
         "ext-phar": "*"

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "88ffb754c378b6610da240d3adcc3770",
-    "content-hash": "af1206ea85a3ce06d326cab55fe68657",
+    "content-hash": "42e54a17b1d6afc8d4d7cbd282235e2a",
     "packages": [
         {
             "name": "zendframework/zend-eventmanager",
@@ -59,7 +58,7 @@
                 "events",
                 "zf2"
             ],
-            "time": "2016-02-18 20:53:00"
+            "time": "2016-02-18T20:53:00+00:00"
         }
     ],
     "packages-dev": [
@@ -129,7 +128,7 @@
                 "docblock",
                 "parser"
             ],
-            "time": "2015-08-31 12:32:49"
+            "time": "2015-08-31T12:32:49+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -183,7 +182,7 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14 21:17:01"
+            "time": "2015-06-14T21:17:01+00:00"
         },
         {
             "name": "doctrine/lexer",
@@ -237,41 +236,234 @@
                 "lexer",
                 "parser"
             ],
-            "time": "2014-09-09 13:34:57"
+            "time": "2014-09-09T13:34:57+00:00"
         },
         {
-            "name": "phpdocumentor/reflection-docblock",
-            "version": "2.0.4",
+            "name": "myclabs/deep-copy",
+            "version": "1.6.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "d68dbdc53dc358a816f00b300704702b2eaff7b8"
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "8e6e04167378abf1ddb4d3522d8755c5fd90d102"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/d68dbdc53dc358a816f00b300704702b2eaff7b8",
-                "reference": "d68dbdc53dc358a816f00b300704702b2eaff7b8",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/8e6e04167378abf1ddb4d3522d8755c5fd90d102",
+                "reference": "8e6e04167378abf1ddb4d3522d8755c5fd90d102",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0"
+                "doctrine/collections": "1.*",
+                "phpunit/phpunit": "~4.1"
             },
-            "suggest": {
-                "dflydev/markdown": "~1.0",
-                "erusev/parsedown": "~1.0"
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "homepage": "https://github.com/myclabs/DeepCopy",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "time": "2017-04-12T18:52:22+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/2df402786ab5368a0169091f61a7c1e0eb6852d0",
+                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-phar": "*",
+                "phar-io/version": "^1.0.1",
+                "php": "^5.6 || ^7.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "1.0.x-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "phpDocumentor": [
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "time": "2017-03-05T18:14:27+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/a70c0ced4be299a63d32fa96d9281d03e94041df",
+                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "time": "2017-03-05T17:38:23+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-common",
+            "version": "1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "144c307535e82c8fdcaacbcfc1d6d8eeb896687c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
+                "reference": "144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
+            "homepage": "http://www.phpdoc.org",
+            "keywords": [
+                "FQSEN",
+                "phpDocumentor",
+                "phpdoc",
+                "reflection",
+                "static analysis"
+            ],
+            "time": "2015-12-27T11:43:31+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-docblock",
+            "version": "3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+                "reference": "8331b5efe816ae05461b7ca1e721c01b46bafb3e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/8331b5efe816ae05461b7ca1e721c01b46bafb3e",
+                "reference": "8331b5efe816ae05461b7ca1e721c01b46bafb3e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5",
+                "phpdocumentor/reflection-common": "^1.0@dev",
+                "phpdocumentor/type-resolver": "^0.2.0",
+                "webmozart/assert": "^1.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^0.9.4",
+                "phpunit/phpunit": "^4.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
                         "src/"
                     ]
                 }
@@ -283,39 +475,88 @@
             "authors": [
                 {
                     "name": "Mike van Riel",
-                    "email": "mike.vanriel@naenius.com"
+                    "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2015-02-03 12:10:50"
+            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "time": "2016-09-30T07:12:33+00:00"
         },
         {
-            "name": "phpspec/prophecy",
-            "version": "v1.6.0",
+            "name": "phpdocumentor/type-resolver",
+            "version": "0.2.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "3c91bdf81797d725b14cb62906f9a4ce44235972"
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/3c91bdf81797d725b14cb62906f9a4ce44235972",
-                "reference": "3c91bdf81797d725b14cb62906f9a4ce44235972",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb",
+                "reference": "e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5",
+                "phpdocumentor/reflection-common": "^1.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^0.9.4",
+                "phpunit/phpunit": "^5.2||^4.8.24"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "time": "2016-11-25T06:54:22+00:00"
+        },
+        {
+            "name": "phpspec/prophecy",
+            "version": "v1.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpspec/prophecy.git",
+                "reference": "93d39f1f7f9326d746203c7c056f300f7f126073"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/93d39f1f7f9326d746203c7c056f300f7f126073",
+                "reference": "93d39f1f7f9326d746203c7c056f300f7f126073",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.3|^7.0",
-                "phpdocumentor/reflection-docblock": "~2.0",
-                "sebastian/comparator": "~1.1",
-                "sebastian/recursion-context": "~1.0"
+                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2",
+                "sebastian/comparator": "^1.1|^2.0",
+                "sebastian/recursion-context": "^1.0|^2.0|^3.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "~2.0"
+                "phpspec/phpspec": "^2.5|^3.2",
+                "phpunit/phpunit": "^4.8 || ^5.6.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.5.x-dev"
+                    "dev-master": "1.6.x-dev"
                 }
             },
             "autoload": {
@@ -348,43 +589,45 @@
                 "spy",
                 "stub"
             ],
-            "time": "2016-02-15 07:46:21"
+            "time": "2017-03-02T20:05:34+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "2.2.4",
+            "version": "5.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "eabf68b476ac7d0f73793aada060f1c1a9bf8979"
+                "reference": "dc421f9ca5082a0c0cb04afb171c765f79add85b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/eabf68b476ac7d0f73793aada060f1c1a9bf8979",
-                "reference": "eabf68b476ac7d0f73793aada060f1c1a9bf8979",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/dc421f9ca5082a0c0cb04afb171c765f79add85b",
+                "reference": "dc421f9ca5082a0c0cb04afb171c765f79add85b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "phpunit/php-file-iterator": "~1.3",
-                "phpunit/php-text-template": "~1.2",
-                "phpunit/php-token-stream": "~1.3",
-                "sebastian/environment": "^1.3.2",
-                "sebastian/version": "~1.0"
+                "ext-dom": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.0",
+                "phpunit/php-file-iterator": "^1.3",
+                "phpunit/php-text-template": "^1.2",
+                "phpunit/php-token-stream": "^1.4.11 || ^2.0",
+                "sebastian/code-unit-reverse-lookup": "^1.0",
+                "sebastian/environment": "^3.0",
+                "sebastian/version": "^2.0",
+                "theseer/tokenizer": "^1.1"
             },
             "require-dev": {
-                "ext-xdebug": ">=2.1.4",
-                "phpunit/phpunit": "~4"
+                "ext-xdebug": "^2.5",
+                "phpunit/phpunit": "^6.0"
             },
             "suggest": {
-                "ext-dom": "*",
-                "ext-xdebug": ">=2.2.1",
-                "ext-xmlwriter": "*"
+                "ext-xdebug": "^2.5.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.2.x-dev"
+                    "dev-master": "5.2.x-dev"
                 }
             },
             "autoload": {
@@ -410,20 +653,20 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-10-06 15:47:00"
+            "time": "2017-04-21T08:03:57+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.1",
+            "version": "1.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0"
+                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
-                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
+                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
                 "shasum": ""
             },
             "require": {
@@ -457,7 +700,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2015-06-21 13:08:43"
+            "time": "2016-10-03T07:40:28+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -498,29 +741,34 @@
             "keywords": [
                 "template"
             ],
-            "time": "2015-06-21 13:50:34"
+            "time": "2015-06-21T13:50:34+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "1.0.8",
+            "version": "1.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "38e9124049cf1a164f1e4537caf19c99bf1eb260"
+                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/38e9124049cf1a164f1e4537caf19c99bf1eb260",
-                "reference": "38e9124049cf1a164f1e4537caf19c99bf1eb260",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
+                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^5.3.3 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4|~5"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -542,20 +790,20 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2016-05-12 18:03:57"
+            "time": "2017-02-26T11:10:40+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "1.4.8",
+            "version": "1.4.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da"
+                "reference": "e03f8f67534427a787e21a385a67ec3ca6978ea7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da",
-                "reference": "3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/e03f8f67534427a787e21a385a67ec3ca6978ea7",
+                "reference": "e03f8f67534427a787e21a385a67ec3ca6978ea7",
                 "shasum": ""
             },
             "require": {
@@ -591,45 +839,57 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2015-09-15 10:49:45"
+            "time": "2017-02-27T10:12:30+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "4.8.26",
+            "version": "6.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "fc1d8cd5b5de11625979125c5639347896ac2c74"
+                "reference": "f2786490399836d2a544a34785c4a8d3ab32cf0e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/fc1d8cd5b5de11625979125c5639347896ac2c74",
-                "reference": "fc1d8cd5b5de11625979125c5639347896ac2c74",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/f2786490399836d2a544a34785c4a8d3ab32cf0e",
+                "reference": "f2786490399836d2a544a34785c4a8d3ab32cf0e",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-json": "*",
-                "ext-pcre": "*",
-                "ext-reflection": "*",
-                "ext-spl": "*",
-                "php": ">=5.3.3",
-                "phpspec/prophecy": "^1.3.1",
-                "phpunit/php-code-coverage": "~2.1",
-                "phpunit/php-file-iterator": "~1.4",
-                "phpunit/php-text-template": "~1.2",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "myclabs/deep-copy": "^1.3",
+                "phar-io/manifest": "^1.0.1",
+                "phar-io/version": "^1.0",
+                "php": "^7.0",
+                "phpspec/prophecy": "^1.7",
+                "phpunit/php-code-coverage": "^5.2",
+                "phpunit/php-file-iterator": "^1.4",
+                "phpunit/php-text-template": "^1.2",
                 "phpunit/php-timer": "^1.0.6",
-                "phpunit/phpunit-mock-objects": "~2.3",
-                "sebastian/comparator": "~1.1",
-                "sebastian/diff": "~1.2",
-                "sebastian/environment": "~1.3",
-                "sebastian/exporter": "~1.2",
-                "sebastian/global-state": "~1.0",
-                "sebastian/version": "~1.0",
-                "symfony/yaml": "~2.1|~3.0"
+                "phpunit/phpunit-mock-objects": "^4.0",
+                "sebastian/comparator": "^2.0",
+                "sebastian/diff": "^1.4.3 || ^2.0",
+                "sebastian/environment": "^3.0.2",
+                "sebastian/exporter": "^3.1",
+                "sebastian/global-state": "^1.1 || ^2.0",
+                "sebastian/object-enumerator": "^3.0.2",
+                "sebastian/resource-operations": "^1.0",
+                "sebastian/version": "^2.0"
+            },
+            "conflict": {
+                "phpdocumentor/reflection-docblock": "3.0.2",
+                "phpunit/dbunit": "<3.0"
+            },
+            "require-dev": {
+                "ext-pdo": "*"
             },
             "suggest": {
-                "phpunit/php-invoker": "~1.1"
+                "ext-xdebug": "*",
+                "phpunit/php-invoker": "^1.1"
             },
             "bin": [
                 "phpunit"
@@ -637,7 +897,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.8.x-dev"
+                    "dev-master": "6.2.x-dev"
                 }
             },
             "autoload": {
@@ -663,30 +923,33 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-05-17 03:09:28"
+            "time": "2017-06-13T14:07:07+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "2.3.8",
+            "version": "4.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "ac8e7a3db35738d56ee9a76e78a4e03d97628983"
+                "reference": "d8833b396dce9162bb2eb5d59aee5a3ab3cfa5b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/ac8e7a3db35738d56ee9a76e78a4e03d97628983",
-                "reference": "ac8e7a3db35738d56ee9a76e78a4e03d97628983",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/d8833b396dce9162bb2eb5d59aee5a3ab3cfa5b4",
+                "reference": "d8833b396dce9162bb2eb5d59aee5a3ab3cfa5b4",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
-                "php": ">=5.3.3",
-                "phpunit/php-text-template": "~1.2",
-                "sebastian/exporter": "~1.2"
+                "php": "^7.0",
+                "phpunit/php-text-template": "^1.2",
+                "sebastian/exporter": "^3.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<6.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^6.0"
             },
             "suggest": {
                 "ext-soap": "*"
@@ -694,7 +957,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.3.x-dev"
+                    "dev-master": "4.0.x-dev"
                 }
             },
             "autoload": {
@@ -719,34 +982,79 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2015-10-02 06:51:40"
+            "time": "2017-06-30T08:15:21+00:00"
         },
         {
-            "name": "sebastian/comparator",
-            "version": "1.2.0",
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22"
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/937efb279bd37a375bcadf584dec0726f84dbf22",
-                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
+                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "sebastian/diff": "~1.2",
-                "sebastian/exporter": "~1.2"
+                "php": "^5.6 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^5.7 || ^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2.x-dev"
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "time": "2017-03-04T06:30:41+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "20f84f468cb67efee293246e6a09619b891f55f0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/20f84f468cb67efee293246e6a09619b891f55f0",
+                "reference": "20f84f468cb67efee293246e6a09619b891f55f0",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0",
+                "sebastian/diff": "^1.2",
+                "sebastian/exporter": "^3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -783,27 +1091,27 @@
                 "compare",
                 "equality"
             ],
-            "time": "2015-07-26 15:48:44"
+            "time": "2017-03-03T06:26:08+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "1.4.1",
+            "version": "1.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e"
+                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/13edfd8706462032c2f52b4b862974dd46b71c9e",
-                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/7f066a26a962dbe58ddea9f72a4e82874a3975a4",
+                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^5.3.3 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.8"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
             },
             "type": "library",
             "extra": {
@@ -835,32 +1143,32 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2015-12-08 07:14:41"
+            "time": "2017-05-22T07:24:03+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "1.3.7",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "4e8f0da10ac5802913afc151413bc8c53b6c2716"
+                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/4e8f0da10ac5802913afc151413bc8c53b6c2716",
-                "reference": "4e8f0da10ac5802913afc151413bc8c53b6c2716",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
+                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^6.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev"
+                    "dev-master": "3.1.x-dev"
                 }
             },
             "autoload": {
@@ -885,33 +1193,34 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-05-17 03:18:57"
+            "time": "2017-07-01T08:51:00+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "1.2.1",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "7ae5513327cb536431847bcc0c10edba2701064e"
+                "reference": "234199f4528de6d12aaa58b612e98f7d36adb937"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/7ae5513327cb536431847bcc0c10edba2701064e",
-                "reference": "7ae5513327cb536431847bcc0c10edba2701064e",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/234199f4528de6d12aaa58b612e98f7d36adb937",
+                "reference": "234199f4528de6d12aaa58b612e98f7d36adb937",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "sebastian/recursion-context": "~1.0"
+                "php": "^7.0",
+                "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "ext-mbstring": "*",
+                "phpunit/phpunit": "^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2.x-dev"
+                    "dev-master": "3.1.x-dev"
                 }
             },
             "autoload": {
@@ -951,27 +1260,27 @@
                 "export",
                 "exporter"
             ],
-            "time": "2015-06-21 07:55:53"
+            "time": "2017-04-03T13:19:02+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "1.1.1",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4"
+                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bc37d50fea7d017d3d340f230811c9f1d7280af4",
-                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
+                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.2"
+                "phpunit/phpunit": "^6.0"
             },
             "suggest": {
                 "ext-uopz": "*"
@@ -979,7 +1288,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -1002,32 +1311,124 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2015-10-12 03:26:01"
+            "time": "2017-04-27T15:39:26+00:00"
         },
         {
-            "name": "sebastian/recursion-context",
-            "version": "1.0.2",
+            "name": "sebastian/object-enumerator",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "913401df809e99e4f47b27cdd781f4a258d58791"
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "31dd3379d16446c5d86dec32ab1ad1f378581ad8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/913401df809e99e4f47b27cdd781f4a258d58791",
-                "reference": "913401df809e99e4f47b27cdd781f4a258d58791",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/31dd3379d16446c5d86dec32ab1ad1f378581ad8",
+                "reference": "31dd3379d16446c5d86dec32ab1ad1f378581ad8",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.0",
+                "sebastian/object-reflector": "^1.0",
+                "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "time": "2017-03-12T15:17:29+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "773f97c67f28de00d397be301821b06708fca0be"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/773f97c67f28de00d397be301821b06708fca0be",
+                "reference": "773f97c67f28de00d397be301821b06708fca0be",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "time": "2017-03-29T09:07:27+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
+                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
                 }
             },
             "autoload": {
@@ -1055,23 +1456,73 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2015-11-11 19:50:13"
+            "time": "2017-03-03T06:23:57+00:00"
         },
         {
-            "name": "sebastian/version",
-            "version": "1.0.6",
+            "name": "sebastian/resource-operations",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6"
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
-                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
                 "shasum": ""
             },
+            "require": {
+                "php": ">=5.6.0"
+            },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "time": "2015-07-28T20:34:47+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -1090,7 +1541,7 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2015-06-21 13:59:46"
+            "time": "2016-10-03T07:35:21+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -1168,38 +1619,79 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2016-04-03 22:58:34"
+            "time": "2016-04-03T22:58:34+00:00"
         },
         {
-            "name": "symfony/yaml",
-            "version": "v3.0.6",
+            "name": "theseer/tokenizer",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/yaml.git",
-                "reference": "0047c8366744a16de7516622c5b7355336afae96"
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "cb2f008f3f05af2893a87208fe6a6c4985483f8b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/0047c8366744a16de7516622c5b7355336afae96",
-                "reference": "0047c8366744a16de7516622c5b7355336afae96",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/cb2f008f3f05af2893a87208fe6a6c4985483f8b",
+                "reference": "cb2f008f3f05af2893a87208fe6a6c4985483f8b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9"
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "time": "2017-04-07T12:08:54+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/assert.git",
+                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/2db61e59ff05fe5126d152bd0655c9ea113e550f",
+                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6",
+                "sebastian/version": "^1.0.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "1.3-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "Symfony\\Component\\Yaml\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
+                    "Webmozart\\Assert\\": "src/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1207,17 +1699,17 @@
             ],
             "authors": [
                 {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
                 }
             ],
-            "description": "Symfony Yaml Component",
-            "homepage": "https://symfony.com",
-            "time": "2016-03-04 07:55:57"
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "time": "2016-11-23T20:04:58+00:00"
         },
         {
             "name": "zendframework/zend-stdlib",
@@ -1262,7 +1754,7 @@
                 "stdlib",
                 "zf2"
             ],
-            "time": "2016-04-12 21:19:36"
+            "time": "2016-04-12T21:19:36+00:00"
         }
     ],
     "aliases": [],

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,23 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
-         colors="true">
+<phpunit bootstrap="./vendor/autoload.php" colors="true">
     <testsuites>
         <testsuite name="zend-code Test Suite">
-            <directory>./test/</directory>
+            <directory>./test</directory>
         </testsuite>
     </testsuites>
-
-    <groups>
-        <exclude>
-            <group>disable</group>
-        </exclude>
-    </groups>
-
     <filter>
         <whitelist addUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
+            <directory>./src</directory>
         </whitelist>
     </filter>
 

--- a/test/Annotation/AnnotationManagerTest.php
+++ b/test/Annotation/AnnotationManagerTest.php
@@ -29,27 +29,27 @@ class AnnotationManagerTest extends TestCase
     public function testAllowsMultipleParsingStrategies()
     {
         $genericParser = new Annotation\Parser\GenericAnnotationParser();
-        $genericParser->registerAnnotation(__NAMESPACE__ . '\TestAsset\Foo');
+        $genericParser->registerAnnotation(TestAsset\Foo::class);
         $doctrineParser = new Annotation\Parser\DoctrineAnnotationParser();
-        $doctrineParser->registerAnnotation(__NAMESPACE__ . '\TestAsset\DoctrineAnnotation');
+        $doctrineParser->registerAnnotation(TestAsset\DoctrineAnnotation::class);
 
         $this->manager->attach($genericParser);
         $this->manager->attach($doctrineParser);
 
-        $reflection = new Reflection\ClassReflection(__NAMESPACE__ . '\TestAsset\EntityWithMixedAnnotations');
+        $reflection = new Reflection\ClassReflection(TestAsset\EntityWithMixedAnnotations::class);
         $prop = $reflection->getProperty('test');
         $annotations = $prop->getAnnotations($this->manager);
 
-        $this->assertTrue($annotations->hasAnnotation(__NAMESPACE__ . '\TestAsset\Foo'));
-        $this->assertTrue($annotations->hasAnnotation(__NAMESPACE__ . '\TestAsset\DoctrineAnnotation'));
-        $this->assertFalse($annotations->hasAnnotation(__NAMESPACE__ . '\TestAsset\Bar'));
+        $this->assertTrue($annotations->hasAnnotation(TestAsset\Foo::class));
+        $this->assertTrue($annotations->hasAnnotation(TestAsset\DoctrineAnnotation::class));
+        $this->assertFalse($annotations->hasAnnotation(TestAsset\Bar::class));
 
         foreach ($annotations as $annotation) {
             switch (get_class($annotation)) {
-                case __NAMESPACE__ . '\TestAsset\Foo':
+                case TestAsset\Foo::class:
                     $this->assertEquals('first', $annotation->content);
                     break;
-                case __NAMESPACE__ . '\TestAsset\DoctrineAnnotation':
+                case TestAsset\DoctrineAnnotation::class:
                     $this->assertEquals(['foo' => 'bar', 'bar' => 'baz'], $annotation->value);
                     break;
                 default:

--- a/test/Annotation/AnnotationManagerTest.php
+++ b/test/Annotation/AnnotationManagerTest.php
@@ -9,7 +9,7 @@
 
 namespace ZendTest\Code\Annotation;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\Code\Annotation;
 use Zend\Code\Reflection;
 

--- a/test/Annotation/DoctrineAnnotationParserTest.php
+++ b/test/Annotation/DoctrineAnnotationParserTest.php
@@ -9,7 +9,7 @@
 
 namespace ZendTest\Code\Annotation;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\Code\Annotation;
 use Zend\Code\Annotation\Parser\DoctrineAnnotationParser;
 use Zend\EventManager\Event;

--- a/test/Annotation/DoctrineAnnotationParserTest.php
+++ b/test/Annotation/DoctrineAnnotationParserTest.php
@@ -12,6 +12,7 @@ namespace ZendTest\Code\Annotation;
 use PHPUnit\Framework\TestCase;
 use Zend\Code\Annotation;
 use Zend\Code\Annotation\Parser\DoctrineAnnotationParser;
+use Zend\Code\Exception\InvalidArgumentException;
 use Zend\EventManager\Event;
 
 class DoctrineAnnotationParserTest extends TestCase
@@ -81,11 +82,9 @@ class DoctrineAnnotationParserTest extends TestCase
         $this->assertFalse($this->parser->onCreateAnnotation($event));
     }
 
-    /**
-     * @expectedException \Zend\Code\Exception\InvalidArgumentException
-     */
     public function testRegisterAnnotationsThrowsException()
     {
+        $this->expectException(InvalidArgumentException::class);
         $this->parser->registerAnnotations('some string');
     }
 

--- a/test/Annotation/DoctrineAnnotationParserTest.php
+++ b/test/Annotation/DoctrineAnnotationParserTest.php
@@ -10,7 +10,6 @@
 namespace ZendTest\Code\Annotation;
 
 use PHPUnit\Framework\TestCase;
-use Zend\Code\Annotation;
 use Zend\Code\Annotation\Parser\DoctrineAnnotationParser;
 use Zend\Code\Exception\InvalidArgumentException;
 use Zend\EventManager\Event;

--- a/test/Annotation/GenericAnnotationParserTest.php
+++ b/test/Annotation/GenericAnnotationParserTest.php
@@ -9,7 +9,7 @@
 
 namespace ZendTest\Code\Annotation;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\Code\Annotation;
 use Zend\EventManager\Event;
 

--- a/test/Annotation/GenericAnnotationParserTest.php
+++ b/test/Annotation/GenericAnnotationParserTest.php
@@ -11,6 +11,7 @@ namespace ZendTest\Code\Annotation;
 
 use PHPUnit\Framework\TestCase;
 use Zend\Code\Annotation;
+use Zend\Code\Exception\InvalidArgumentException;
 use Zend\EventManager\Event;
 
 class GenericAnnotationParserTest extends TestCase
@@ -87,21 +88,18 @@ class GenericAnnotationParserTest extends TestCase
         $this->assertEquals('test content', $test->content);
     }
 
-    /**
-     * @expectedException \Zend\Code\Exception\InvalidArgumentException
-     */
     public function testRegisterAnnotationAllowsAnnotationInterfaceOnly()
     {
+        $this->expectException(InvalidArgumentException::class);
         $this->parser->registerAnnotation(new \stdClass());
     }
 
-    /**
-     * @expectedException \Zend\Code\Exception\InvalidArgumentException
-     */
     public function testAllowRegistrationOnceOnly()
     {
         $bar = new TestAsset\Bar();
         $this->parser->registerAnnotation($bar);
+
+        $this->expectException(InvalidArgumentException::class);
         $this->parser->registerAnnotation($bar);
     }
 
@@ -113,19 +111,15 @@ class GenericAnnotationParserTest extends TestCase
         $this->assertInstanceOf(__NAMESPACE__ . '\TestAsset\Foo', $test);
     }
 
-    /**
-     * @expectedException \Zend\Code\Exception\InvalidArgumentException
-     */
     public function testRegisterAnnotationsThrowsException()
     {
+        $this->expectException(InvalidArgumentException::class);
         $this->parser->registerAnnotations('some string');
     }
 
-    /**
-     * @expectedException \Zend\Code\Exception\InvalidArgumentException
-     */
     public function testSetAliasNotRegisteredClassThrowsException()
     {
+        $this->expectException(InvalidArgumentException::class);
         $this->parser->setAlias('bar', 'foo');
     }
 }

--- a/test/Generator/AbstractGeneratorTest.php
+++ b/test/Generator/AbstractGeneratorTest.php
@@ -10,6 +10,8 @@
 namespace ZendTest\Code\Generator;
 
 use PHPUnit\Framework\TestCase;
+use Zend\Code\Generator\AbstractGenerator;
+use Zend\Code\Generator\Exception\InvalidArgumentException;
 
 /**
  * @group Zend_Code_Generator
@@ -29,13 +31,9 @@ class AbstractGeneratorTest extends TestCase
         $this->assertEquals('foo', $generator->getIndentation());
     }
 
-    /**
-     * @expectedException \Zend\Code\Generator\Exception\InvalidArgumentException
-     */
     public function testSetOptionsThrowsExceptionOnInvalidArgument()
     {
-        $generator = $this->getMockForAbstractClass('Zend\Code\Generator\AbstractGenerator', [
-            'sss',
-        ]);
+        $this->expectException(InvalidArgumentException::class);
+        $this->getMockForAbstractClass(AbstractGenerator::class, ['sss']);
     }
 }

--- a/test/Generator/AbstractGeneratorTest.php
+++ b/test/Generator/AbstractGeneratorTest.php
@@ -9,11 +9,13 @@
 
 namespace ZendTest\Code\Generator;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group Zend_Code_Generator
  * @group Zend_Code_Generator_Php
  */
-class AbstractGeneratorTest extends \PHPUnit_Framework_TestCase
+class AbstractGeneratorTest extends TestCase
 {
     public function testConstructor()
     {

--- a/test/Generator/AbstractGeneratorTest.php
+++ b/test/Generator/AbstractGeneratorTest.php
@@ -12,6 +12,7 @@ namespace ZendTest\Code\Generator;
 use PHPUnit\Framework\TestCase;
 use Zend\Code\Generator\AbstractGenerator;
 use Zend\Code\Generator\Exception\InvalidArgumentException;
+use Zend\Code\Generator\GeneratorInterface;
 
 /**
  * @group Zend_Code_Generator
@@ -21,13 +22,13 @@ class AbstractGeneratorTest extends TestCase
 {
     public function testConstructor()
     {
-        $generator = $this->getMockForAbstractClass('Zend\Code\Generator\AbstractGenerator', [
+        $generator = $this->getMockForAbstractClass(AbstractGenerator::class, [
             [
                 'indentation' => 'foo',
-            ]
+            ],
         ]);
 
-        $this->assertInstanceOf('Zend\Code\Generator\GeneratorInterface', $generator);
+        $this->assertInstanceOf(GeneratorInterface::class, $generator);
         $this->assertEquals('foo', $generator->getIndentation());
     }
 

--- a/test/Generator/AbstractMemberGeneratorTest.php
+++ b/test/Generator/AbstractMemberGeneratorTest.php
@@ -38,11 +38,9 @@ class AbstractMemberGeneratorTest extends TestCase
         $this->assertEquals(true, $this->fixture->isFinal());
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testSetDocBlockThrowsExceptionWithInvalidType()
     {
+        $this->expectException(InvalidArgumentException::class);
         $this->fixture->setDocBlock(new \stdClass());
     }
 }

--- a/test/Generator/AbstractMemberGeneratorTest.php
+++ b/test/Generator/AbstractMemberGeneratorTest.php
@@ -22,7 +22,7 @@ class AbstractMemberGeneratorTest extends TestCase
 
     protected function setUp()
     {
-        $this->fixture = $this->getMockForAbstractClass('Zend\Code\Generator\AbstractMemberGenerator');
+        $this->fixture = $this->getMockForAbstractClass(AbstractMemberGenerator::class);
     }
 
     public function testSetFlagsWithArray()

--- a/test/Generator/AbstractMemberGeneratorTest.php
+++ b/test/Generator/AbstractMemberGeneratorTest.php
@@ -9,10 +9,11 @@
 
 namespace ZendTest\Code\Generator;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Code\Generator\AbstractMemberGenerator;
 use Zend\Code\Generator\Exception\InvalidArgumentException;
 
-class AbstractMemberGeneratorTest extends \PHPUnit_Framework_TestCase
+class AbstractMemberGeneratorTest extends TestCase
 {
     /**
      * @var AbstractMemberGenerator

--- a/test/Generator/ClassGeneratorTest.php
+++ b/test/Generator/ClassGeneratorTest.php
@@ -28,7 +28,7 @@ class ClassGeneratorTest extends TestCase
     public function testConstruction()
     {
         $class = new ClassGenerator();
-        $this->isInstanceOf($class, 'Zend\Code\Generator\ClassGenerator');
+        $this->assertInstanceOf(ClassGenerator::class, $class);
     }
 
     public function testNameAccessors()
@@ -115,7 +115,7 @@ class ClassGeneratorTest extends TestCase
         ]);
 
         $properties = $classGenerator->getProperties();
-        $this->assertEquals(count($properties), 2);
+        $this->assertCount(2, $properties);
         $this->assertInstanceOf('Zend\Code\Generator\PropertyGenerator', current($properties));
 
         $property = $classGenerator->getProperty('propTwo');
@@ -124,7 +124,7 @@ class ClassGeneratorTest extends TestCase
 
         // add a new property
         $classGenerator->addProperty('prop3');
-        $this->assertEquals(count($classGenerator->getProperties()), 3);
+        $this->assertCount(3, $classGenerator->getProperties());
     }
 
     public function testSetPropertyAlreadyExistsThrowsException()
@@ -155,11 +155,11 @@ class ClassGeneratorTest extends TestCase
         ]);
 
         $methods = $classGenerator->getMethods();
-        $this->assertEquals(count($methods), 2);
-        $this->isInstanceOf(current($methods), '\Zend\Code\Generator\PhpMethod');
+        $this->assertCount(2, $methods);
+        $this->assertInstanceOf(MethodGenerator::class, current($methods));
 
         $method = $classGenerator->getMethod('methodOne');
-        $this->isInstanceOf($method, '\Zend\Code\Generator\PhpMethod');
+        $this->assertInstanceOf(MethodGenerator::class, $method);
         $this->assertEquals($method->getName(), 'methodOne');
 
         // add a new property
@@ -980,7 +980,7 @@ CODE;
         $classGenerator->addTraitOverride('myTrait::foo', 'hisTrait');
 
         $overrides = $classGenerator->getTraitOverrides();
-        $this->assertEquals(count($overrides), 1);
+        $this->assertCount(1, $overrides);
         $this->assertEquals(key($overrides), 'myTrait::foo');
         $this->assertEquals($overrides['myTrait::foo'][0], 'hisTrait');
     }
@@ -992,7 +992,7 @@ CODE;
         $classGenerator->addTraitOverride('myTrait::foo', ['hisTrait', 'thatTrait']);
 
         $overrides = $classGenerator->getTraitOverrides();
-        $this->assertEquals(count($overrides['myTrait::foo']), 2);
+        $this->assertCount(2, $overrides['myTrait::foo']);
         $this->assertEquals($overrides['myTrait::foo'][1], 'thatTrait');
     }
 
@@ -1058,12 +1058,12 @@ CODE;
         $classGenerator->addTraitOverride('myTrait::foo', ['hisTrait', 'thatTrait']);
 
         $overrides = $classGenerator->getTraitOverrides();
-        $this->assertEquals(count($overrides['myTrait::foo']), 2);
+        $this->assertCount(2, $overrides['myTrait::foo']);
 
         $classGenerator->removeTraitOverride('myTrait::foo', 'hisTrait');
         $overrides = $classGenerator->getTraitOverrides();
 
-        $this->assertEquals(count($overrides['myTrait::foo']), 1);
+        $this->assertCount(1, $overrides['myTrait::foo']);
         $this->assertEquals($overrides['myTrait::foo'][1], 'thatTrait');
     }
 
@@ -1074,12 +1074,12 @@ CODE;
         $classGenerator->addTraitOverride('myTrait::foo', ['hisTrait', 'thatTrait']);
 
         $overrides = $classGenerator->getTraitOverrides();
-        $this->assertEquals(count($overrides['myTrait::foo']), 2);
+        $this->assertCount(2, $overrides['myTrait::foo']);
 
         $classGenerator->removeTraitOverride('myTrait::foo');
         $overrides = $classGenerator->getTraitOverrides();
 
-        $this->assertEquals(count($overrides), 0);
+        $this->assertCount(0, $overrides);
     }
 
     /**

--- a/test/Generator/ClassGeneratorTest.php
+++ b/test/Generator/ClassGeneratorTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\Code\Generator;
 
+use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
 use Zend\Code\Generator\ClassGenerator;
 use Zend\Code\Generator\DocBlockGenerator;
@@ -16,12 +17,13 @@ use Zend\Code\Generator\Exception\InvalidArgumentException;
 use Zend\Code\Generator\PropertyGenerator;
 use Zend\Code\Generator\MethodGenerator;
 use Zend\Code\Reflection\ClassReflection;
+use Zend\Code\Generator\Exception\ExceptionInterface;
 
 /**
  * @group Zend_Code_Generator
  * @group Zend_Code_Generator_Php
  */
-class ClassGeneratorTest extends \PHPUnit_Framework_TestCase
+class ClassGeneratorTest extends TestCase
 {
     public function testConstruction()
     {
@@ -130,10 +132,8 @@ class ClassGeneratorTest extends \PHPUnit_Framework_TestCase
         $classGenerator = new ClassGenerator();
         $classGenerator->addProperty('prop3');
 
-        $this->setExpectedException(
-            'Zend\Code\Generator\Exception\InvalidArgumentException',
-            'A property by name prop3 already exists in this class'
-        );
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('A property by name prop3 already exists in this class');
         $classGenerator->addProperty('prop3');
     }
 
@@ -141,10 +141,8 @@ class ClassGeneratorTest extends \PHPUnit_Framework_TestCase
     {
         $classGenerator = new ClassGenerator();
 
-        $this->setExpectedException(
-            'Zend\Code\Generator\Exception\InvalidArgumentException',
-            'Zend\Code\Generator\ClassGenerator::addProperty expects string for name'
-        );
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Zend\Code\Generator\ClassGenerator::addProperty expects string for name');
         $classGenerator->addProperty(true);
     }
 
@@ -173,10 +171,8 @@ class ClassGeneratorTest extends \PHPUnit_Framework_TestCase
     {
         $classGenerator = new ClassGenerator();
 
-        $this->setExpectedException(
-            'Zend\Code\Generator\Exception\ExceptionInterface',
-            'Zend\Code\Generator\ClassGenerator::addMethod expects string for name'
-        );
+        $this->expectException(ExceptionInterface::class);
+        $this->expectExceptionMessage('Zend\Code\Generator\ClassGenerator::addMethod expects string for name');
 
         $classGenerator->addMethod(true);
     }
@@ -191,10 +187,8 @@ class ClassGeneratorTest extends \PHPUnit_Framework_TestCase
         $classGenerator = new ClassGenerator();
         $classGenerator->addMethodFromGenerator($methodA);
 
-        $this->setExpectedException(
-            'Zend\Code\Generator\Exception\InvalidArgumentException',
-            'A method by name foo already exists in this class.'
-        );
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('A method by name foo already exists in this class.');
 
         $classGenerator->addMethodFromGenerator($methodB);
     }
@@ -647,10 +641,9 @@ CODE;
      */
     public function testAddConstantThrowsExceptionWithInvalidName()
     {
-        $this->setExpectedException('InvalidArgumentException');
-
         $classGenerator = new ClassGenerator();
 
+        $this->expectException(InvalidArgumentException::class);
         $classGenerator->addConstant([], 'value1');
     }
 
@@ -658,8 +651,7 @@ CODE;
     {
         $classGenerator = new ClassGenerator();
 
-        $this->setExpectedException(InvalidArgumentException::class);
-
+        $this->expectException(InvalidArgumentException::class);
         $classGenerator->addConstant('', 'value');
     }
 
@@ -688,8 +680,7 @@ CODE;
     {
         $classGenerator = new ClassGenerator();
 
-        $this->setExpectedException(InvalidArgumentException::class);
-
+        $this->expectException(InvalidArgumentException::class);
         $classGenerator->addConstant('a', new \stdClass());
     }
 
@@ -714,8 +705,7 @@ CODE;
     {
         $classGenerator = new ClassGenerator();
 
-        $this->setExpectedException(InvalidArgumentException::class);
-
+        $this->expectException(InvalidArgumentException::class);
         $classGenerator->addConstant('a', [new \stdClass()]);
     }
 
@@ -724,11 +714,10 @@ CODE;
      */
     public function testAddConstantThrowsExceptionOnDuplicate()
     {
-        $this->setExpectedException('InvalidArgumentException');
-
         $classGenerator = new ClassGenerator();
-
         $classGenerator->addConstant('x', 'value1');
+
+        $this->expectException('InvalidArgumentException');
         $classGenerator->addConstant('x', 'value1');
     }
 
@@ -929,10 +918,8 @@ CODE;
     {
         $classGenerator = new ClassGenerator();
 
-        $this->setExpectedException(
-            'Zend\Code\Generator\Exception\InvalidArgumentException',
-            'Invalid Format: $method must be in the format of trait::method'
-        );
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid Format: $method must be in the format of trait::method');
 
         $classGenerator->addTrait('myTrait');
         $classGenerator->addTraitAlias('method', 'useMe');
@@ -942,10 +929,8 @@ CODE;
     {
         $classGenerator = new ClassGenerator();
 
-        $this->setExpectedException(
-            'Zend\Code\Generator\Exception\InvalidArgumentException',
-            'Invalid trait: Trait does not exists on this class'
-        );
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid trait: Trait does not exists on this class');
 
         $classGenerator->addTrait('myTrait');
         $classGenerator->addTraitAlias('unknown::method', 'useMe');
@@ -955,10 +940,8 @@ CODE;
     {
         $classGenerator = new ClassGenerator();
 
-        $this->setExpectedException(
-            'Zend\Code\Generator\Exception\InvalidArgumentException',
-            'Invalid Alias: Method name already exists on this class.'
-        );
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid Alias: Method name already exists on this class.');
 
         $classGenerator->addMethod('methodOne');
         $classGenerator->addTrait('myTrait');
@@ -969,8 +952,8 @@ CODE;
     {
         $classGenerator = new ClassGenerator();
 
-        $this->setExpectedException(
-            'Zend\Code\Generator\Exception\InvalidArgumentException',
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
             'Invalid Type: $visibility must of ReflectionMethod::IS_PUBLIC,'
             . ' ReflectionMethod::IS_PRIVATE or ReflectionMethod::IS_PROTECTED'
         );
@@ -983,10 +966,8 @@ CODE;
     {
         $classGenerator = new ClassGenerator();
 
-        $this->setExpectedException(
-            'Zend\Code\Generator\Exception\InvalidArgumentException',
-            'Invalid Alias: $alias must be a string or array.'
-        );
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid Alias: $alias must be a string or array.');
 
         $classGenerator->addTrait('myTrait');
         $classGenerator->addTraitAlias('myTrait::method', new ClassGenerator, 'public');
@@ -1019,10 +1000,8 @@ CODE;
     {
         $classGenerator = new ClassGenerator();
 
-        $this->setExpectedException(
-            'Zend\Code\Generator\Exception\InvalidArgumentException',
-            'Invalid Format: $method must be in the format of trait::method'
-        );
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid Format: $method must be in the format of trait::method');
 
         $classGenerator->addTrait('myTrait');
         $classGenerator->addTraitOverride('method', 'useMe');
@@ -1032,10 +1011,8 @@ CODE;
     {
         $classGenerator = new ClassGenerator();
 
-        $this->setExpectedException(
-            'Zend\Code\Generator\Exception\InvalidArgumentException',
-            'Invalid trait: Trait does not exists on this class'
-        );
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid trait: Trait does not exists on this class');
 
         $classGenerator->addTrait('myTrait');
         $classGenerator->addTraitOverride('unknown::method', 'useMe');
@@ -1045,10 +1022,8 @@ CODE;
     {
         $classGenerator = new ClassGenerator();
 
-        $this->setExpectedException(
-            'Zend\Code\Generator\Exception\InvalidArgumentException',
-            'Missing required argument "traitName" for $method'
-        );
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Missing required argument "traitName" for $method');
 
         $classGenerator->addTrait('myTrait');
         $classGenerator->addTraitOverride(['method' => 'foo'], 'test');
@@ -1058,10 +1033,8 @@ CODE;
     {
         $classGenerator = new ClassGenerator();
 
-        $this->setExpectedException(
-            'Zend\Code\Generator\Exception\InvalidArgumentException',
-            'Invalid Argument: $traitToReplace must be a string or array of strings'
-        );
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid Argument: $traitToReplace must be a string or array of strings');
 
         $classGenerator->addTrait('myTrait');
         $classGenerator->addTraitOverride('myTrait::method', ['methodOne', 4]);
@@ -1071,10 +1044,8 @@ CODE;
     {
         $classGenerator = new ClassGenerator();
 
-        $this->setExpectedException(
-            'Zend\Code\Generator\Exception\InvalidArgumentException',
-            'Missing required argument "method" for $method'
-        );
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Missing required argument "method" for $method');
 
         $classGenerator->addTrait('myTrait');
         $classGenerator->addTraitOverride(['traitName' => 'myTrait'], 'test');

--- a/test/Generator/DocBlock/Tag/AuthorTagTest.php
+++ b/test/Generator/DocBlock/Tag/AuthorTagTest.php
@@ -80,7 +80,7 @@ class AuthorTagTest extends TestCase
 
         /** @var AuthorTag $tag */
         $tag = $this->tagmanager->createTagFromReflection($reflectionTag);
-        $this->assertInstanceOf('Zend\Code\Generator\DocBlock\Tag\AuthorTag', $tag);
+        $this->assertInstanceOf(AuthorTag::class, $tag);
         $this->assertEquals('Mister Miller', $tag->getAuthorName());
         $this->assertEquals('mister.miller@zend.com', $tag->getAuthorEmail());
     }

--- a/test/Generator/DocBlock/Tag/AuthorTagTest.php
+++ b/test/Generator/DocBlock/Tag/AuthorTagTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\Code\Generator\DocBlock\Tag;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Code\Generator\DocBlock\Tag\AuthorTag;
 use Zend\Code\Generator\DocBlock\TagManager;
 use Zend\Code\Reflection\DocBlockReflection;
@@ -17,7 +18,7 @@ use Zend\Code\Reflection\DocBlockReflection;
  * @group Zend_Code_Generator
  * @group Zend_Code_Generator_Php
  */
-class AuthorTagTest extends \PHPUnit_Framework_TestCase
+class AuthorTagTest extends TestCase
 {
     /**
      * @var AuthorTag

--- a/test/Generator/DocBlock/Tag/GenericTagTest.php
+++ b/test/Generator/DocBlock/Tag/GenericTagTest.php
@@ -74,7 +74,7 @@ class GenericTagTest extends TestCase
 
         /** @var GenericTag $tag */
         $tag = $this->tagmanager->createTagFromReflection($reflectionTag);
-        $this->assertInstanceOf('Zend\Code\Generator\DocBlock\Tag\GenericTag', $tag);
+        $this->assertInstanceOf(GenericTag::class, $tag);
         $this->assertEquals('var', $tag->getName());
         $this->assertEquals('string', $tag->getContent());
     }

--- a/test/Generator/DocBlock/Tag/GenericTagTest.php
+++ b/test/Generator/DocBlock/Tag/GenericTagTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\Code\Generator\DocBlock\Tag;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Code\Generator\DocBlock\Tag\GenericTag;
 use Zend\Code\Generator\DocBlock\TagManager;
 use Zend\Code\Reflection\DocBlockReflection;
@@ -17,7 +18,7 @@ use Zend\Code\Reflection\DocBlockReflection;
  * @group Zend_Code_Generator
  * @group Zend_Code_Generator_Php
  */
-class GenericTagTest extends \PHPUnit_Framework_TestCase
+class GenericTagTest extends TestCase
 {
     /**
      * @var GenericTag

--- a/test/Generator/DocBlock/Tag/LicenseTagTest.php
+++ b/test/Generator/DocBlock/Tag/LicenseTagTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\Code\Generator\DocBlock\Tag;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Code\Generator\DocBlock\Tag\LicenseTag;
 use Zend\Code\Generator\DocBlock\TagManager;
 use Zend\Code\Reflection\DocBlockReflection;
@@ -17,7 +18,7 @@ use Zend\Code\Reflection\DocBlockReflection;
  * @group Zend_Code_Generator
  * @group Zend_Code_Generator_Php
  */
-class LicenseTagTest extends \PHPUnit_Framework_TestCase
+class LicenseTagTest extends TestCase
 {
     /**
      * @var LicenseTag

--- a/test/Generator/DocBlock/Tag/LicenseTagTest.php
+++ b/test/Generator/DocBlock/Tag/LicenseTagTest.php
@@ -80,7 +80,7 @@ class LicenseTagTest extends TestCase
 
         /** @var LicenseTag $tag */
         $tag = $this->tagmanager->createTagFromReflection($reflectionTag);
-        $this->assertInstanceOf('Zend\Code\Generator\DocBlock\Tag\LicenseTag', $tag);
+        $this->assertInstanceOf(LicenseTag::class, $tag);
         $this->assertEquals('http://zend.com', $tag->getUrl());
         $this->assertEquals('License', $tag->getLicenseName());
     }

--- a/test/Generator/DocBlock/Tag/MethodTagTest.php
+++ b/test/Generator/DocBlock/Tag/MethodTagTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\Code\Generator\DocBlock\Tag;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Code\Generator\DocBlock\Tag\MethodTag;
 use Zend\Code\Generator\DocBlock\TagManager;
 use Zend\Code\Reflection\DocBlockReflection;
@@ -17,7 +18,7 @@ use Zend\Code\Reflection\DocBlockReflection;
  * @group Zend_Code_Generator
  * @group Zend_Code_Generator_Php
  */
-class MethodTagTest extends \PHPUnit_Framework_TestCase
+class MethodTagTest extends TestCase
 {
     /**
      * @var MethodTag

--- a/test/Generator/DocBlock/Tag/MethodTagTest.php
+++ b/test/Generator/DocBlock/Tag/MethodTagTest.php
@@ -90,7 +90,7 @@ class MethodTagTest extends TestCase
 
         /** @var MethodTag $tag */
         $tag = $this->tagmanager->createTagFromReflection($reflectionTag);
-        $this->assertInstanceOf('Zend\Code\Generator\DocBlock\Tag\MethodTag', $tag);
+        $this->assertInstanceOf(MethodTag::class, $tag);
         $this->assertEquals(true, $tag->isStatic());
         $this->assertEquals('int', $tag->getTypesAsString());
         $this->assertEquals('method', $tag->getMethodName());

--- a/test/Generator/DocBlock/Tag/ParamTagTest.php
+++ b/test/Generator/DocBlock/Tag/ParamTagTest.php
@@ -85,7 +85,7 @@ class ParamTagTest extends TestCase
 
         /** @var ParamTag $tag */
         $tag = $this->tagmanager->createTagFromReflection($reflectionTag);
-        $this->assertInstanceOf('Zend\Code\Generator\DocBlock\Tag\ParamTag', $tag);
+        $this->assertInstanceOf(ParamTag::class, $tag);
         $this->assertEquals('foo', $tag->getVariableName());
         $this->assertEquals('description', $tag->getDescription());
         $this->assertEquals('int', $tag->getTypesAsString());

--- a/test/Generator/DocBlock/Tag/ParamTagTest.php
+++ b/test/Generator/DocBlock/Tag/ParamTagTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\Code\Generator\DocBlock\Tag;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Code\Generator\DocBlock\Tag\ParamTag;
 use Zend\Code\Generator\DocBlock\TagManager;
 use Zend\Code\Reflection\DocBlockReflection;
@@ -17,7 +18,7 @@ use Zend\Code\Reflection\DocBlockReflection;
  * @group Zend_Code_Generator
  * @group Zend_Code_Generator_Php
  */
-class ParamTagTest extends \PHPUnit_Framework_TestCase
+class ParamTagTest extends TestCase
 {
     /**
      * @var ParamTag

--- a/test/Generator/DocBlock/Tag/PropertyTagTest.php
+++ b/test/Generator/DocBlock/Tag/PropertyTagTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\Code\Generator\DocBlock\Tag;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Code\Generator\DocBlock\Tag\PropertyTag;
 use Zend\Code\Generator\DocBlock\TagManager;
 use Zend\Code\Reflection\DocBlockReflection;
@@ -17,7 +18,7 @@ use Zend\Code\Reflection\DocBlockReflection;
  * @group Zend_Code_Generator
  * @group Zend_Code_Generator_Php
  */
-class PropertyTagTest extends \PHPUnit_Framework_TestCase
+class PropertyTagTest extends TestCase
 {
     /**
      * @var PropertyTag

--- a/test/Generator/DocBlock/Tag/PropertyTagTest.php
+++ b/test/Generator/DocBlock/Tag/PropertyTagTest.php
@@ -86,7 +86,7 @@ class PropertyTagTest extends TestCase
 
         /** @var PropertyTag $tag */
         $tag = $this->tagmanager->createTagFromReflection($reflectionTag);
-        $this->assertInstanceOf('Zend\Code\Generator\DocBlock\Tag\PropertyTag', $tag);
+        $this->assertInstanceOf(PropertyTag::class, $tag);
         $this->assertEquals('foo', $tag->getPropertyName());
         $this->assertEquals('description', $tag->getDescription());
         $this->assertEquals('int', $tag->getTypesAsString());

--- a/test/Generator/DocBlock/Tag/ReturnTagTest.php
+++ b/test/Generator/DocBlock/Tag/ReturnTagTest.php
@@ -61,7 +61,7 @@ class ReturnTagTest extends TestCase
 
         /** @var ReturnTag $tag */
         $tag = $this->tagmanager->createTagFromReflection($reflectionTag);
-        $this->assertInstanceOf('Zend\Code\Generator\DocBlock\Tag\ReturnTag', $tag);
+        $this->assertInstanceOf(ReturnTag::class, $tag);
         $this->assertEquals('The return', $tag->getDescription());
         $this->assertEquals('int', $tag->getTypesAsString());
     }

--- a/test/Generator/DocBlock/Tag/ReturnTagTest.php
+++ b/test/Generator/DocBlock/Tag/ReturnTagTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\Code\Generator\DocBlock\Tag;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Code\Generator\DocBlock\Tag\ReturnTag;
 use Zend\Code\Generator\DocBlock\TagManager;
 use Zend\Code\Reflection\DocBlockReflection;
@@ -17,7 +18,7 @@ use Zend\Code\Reflection\DocBlockReflection;
  * @group Zend_Code_Generator
  * @group Zend_Code_Generator_Php
  */
-class ReturnTagTest extends \PHPUnit_Framework_TestCase
+class ReturnTagTest extends TestCase
 {
     /**
      * @var ReturnTag

--- a/test/Generator/DocBlock/Tag/ThrowsTagTest.php
+++ b/test/Generator/DocBlock/Tag/ThrowsTagTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\Code\Generator\DocBlock\Tag;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Code\Generator\DocBlock\Tag\ThrowsTag;
 use Zend\Code\Generator\DocBlock\TagManager;
 use Zend\Code\Reflection\DocBlockReflection;
@@ -17,7 +18,7 @@ use Zend\Code\Reflection\DocBlockReflection;
  * @group Zend_Code_Generator
  * @group Zend_Code_Generator_Php
  */
-class ThrowsTagTest extends \PHPUnit_Framework_TestCase
+class ThrowsTagTest extends TestCase
 {
     /**
      * @var ThrowsTag

--- a/test/Generator/DocBlock/Tag/ThrowsTagTest.php
+++ b/test/Generator/DocBlock/Tag/ThrowsTagTest.php
@@ -61,7 +61,7 @@ class ThrowsTagTest extends TestCase
 
         /** @var ThrowsTag $tag */
         $tag = $this->tagmanager->createTagFromReflection($reflectionTag);
-        $this->assertInstanceOf('Zend\Code\Generator\DocBlock\Tag\ThrowsTag', $tag);
+        $this->assertInstanceOf(ThrowsTag::class, $tag);
         $this->assertEquals('description', $tag->getDescription());
         $this->assertEquals('Exception\Invalid', $tag->getTypesAsString());
     }

--- a/test/Generator/DocBlock/Tag/TypableTagTest.php
+++ b/test/Generator/DocBlock/Tag/TypableTagTest.php
@@ -9,13 +9,14 @@
 
 namespace ZendTest\Code\Generator\DocBlock\Tag;
 
+use PHPUnit\Framework\TestCase;
 use ZendTest\Code\Generator\TestAsset\TypeableTag;
 
 /**
  * @group Zend_Code_Generator
  * @group Zend_Code_Generator_Php
  */
-class TypableTagTest extends \PHPUnit_Framework_TestCase
+class TypableTagTest extends TestCase
 {
     /**
      * @var TypeableTag

--- a/test/Generator/DocBlockGeneratorTest.php
+++ b/test/Generator/DocBlockGeneratorTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\Code\Generator;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Code\Generator\DocBlockGenerator;
 use Zend\Code\Generator\DocBlock\Tag;
 use Zend\Code\Reflection\DocBlockReflection;
@@ -17,7 +18,7 @@ use Zend\Code\Reflection\DocBlockReflection;
  * @group      Zend_Code_Generator
  * @group      Zend_Code_Generator_Php
  */
-class DocBlockGeneratorTest extends \PHPUnit_Framework_TestCase
+class DocBlockGeneratorTest extends TestCase
 {
     /**
      * @var DocBlockGenerator

--- a/test/Generator/DocBlockGeneratorTest.php
+++ b/test/Generator/DocBlockGeneratorTest.php
@@ -82,7 +82,7 @@ class DocBlockGeneratorTest extends TestCase
         $this->docBlockGenerator->setTag(['name' => 'blah']);
         $this->docBlockGenerator->setTag($paramTag);
         $this->docBlockGenerator->setTag($returnTag);
-        $this->assertEquals(3, count($this->docBlockGenerator->getTags()));
+        $this->assertCount(3, $this->docBlockGenerator->getTags());
 
         $target = <<<EOS
 /**

--- a/test/Generator/DocBlockGeneratorTest.php
+++ b/test/Generator/DocBlockGeneratorTest.php
@@ -10,8 +10,12 @@
 namespace ZendTest\Code\Generator;
 
 use PHPUnit\Framework\TestCase;
-use Zend\Code\Generator\DocBlockGenerator;
 use Zend\Code\Generator\DocBlock\Tag;
+use Zend\Code\Generator\DocBlock\Tag\AuthorTag;
+use Zend\Code\Generator\DocBlock\Tag\LicenseTag;
+use Zend\Code\Generator\DocBlock\Tag\ParamTag;
+use Zend\Code\Generator\DocBlock\Tag\ReturnTag;
+use Zend\Code\Generator\DocBlockGenerator;
 use Zend\Code\Reflection\DocBlockReflection;
 
 /**
@@ -114,7 +118,7 @@ EOS;
                 [
                     'name'        => 'foo',
                     'description' => 'bar',
-                ]
+                ],
             ],
         ]);
 
@@ -153,54 +157,54 @@ EOS;
         $this->assertEquals($expected, $this->docBlockGenerator->generate());
     }
 
-    public function testDocBlockFromRefelectionLongDescription()
+    public function testDocBlockFromReflectionLongDescription()
     {
         $this->assertEquals('Long Description', $this->reflectionDocBlockGenerator->getLongDescription());
     }
 
-    public function testDocBlockFromRefelectionShortDescription()
+    public function testDocBlockFromReflectionShortDescription()
     {
         $this->assertEquals('Short Description', $this->reflectionDocBlockGenerator->getShortDescription());
     }
 
-    public function testDocBlockFromRefelectionTagsCount()
+    public function testDocBlockFromReflectionTagsCount()
     {
         $this->assertCount(4, $this->reflectionDocBlockGenerator->getTags());
     }
 
     /**
-     * @depends testDocBlockFromRefelectionTagsCount
+     * @depends testDocBlockFromReflectionTagsCount
      */
-    public function testDocBlockFromRefelectionParamTag()
+    public function testDocBlockFromReflectionParamTag()
     {
         $tags = $this->reflectionDocBlockGenerator->getTags();
-        $this->assertInstanceOf('Zend\Code\Generator\DocBlock\Tag\ParamTag', $tags[0]);
+        $this->assertInstanceOf(ParamTag::class, $tags[0]);
     }
 
     /**
-     * @depends testDocBlockFromRefelectionTagsCount
+     * @depends testDocBlockFromReflectionTagsCount
      */
-    public function testDocBlockFromRefelectionAuthorTag()
+    public function testDocBlockFromReflectionAuthorTag()
     {
         $tags = $this->reflectionDocBlockGenerator->getTags();
-        $this->assertInstanceOf('Zend\Code\Generator\DocBlock\Tag\AuthorTag', $tags[1]);
+        $this->assertInstanceOf(AuthorTag::class, $tags[1]);
     }
 
     /**
-     * @depends testDocBlockFromRefelectionTagsCount
+     * @depends testDocBlockFromReflectionTagsCount
      */
-    public function testDocBlockFromRefelectionLicenseTag()
+    public function testDocBlockFromReflectionLicenseTag()
     {
         $tags = $this->reflectionDocBlockGenerator->getTags();
-        $this->assertInstanceOf('Zend\Code\Generator\DocBlock\Tag\LicenseTag', $tags[2]);
+        $this->assertInstanceOf(LicenseTag::class, $tags[2]);
     }
 
     /**
-     * @depends testDocBlockFromRefelectionTagsCount
+     * @depends testDocBlockFromReflectionTagsCount
      */
-    public function testDocBlockFromRefelectionReturnTag()
+    public function testDocBlockFromReflectionReturnTag()
     {
         $tags = $this->reflectionDocBlockGenerator->getTags();
-        $this->assertInstanceOf('Zend\Code\Generator\DocBlock\Tag\ReturnTag', $tags[3]);
+        $this->assertInstanceOf(ReturnTag::class, $tags[3]);
     }
 }

--- a/test/Generator/FileGeneratorTest.php
+++ b/test/Generator/FileGeneratorTest.php
@@ -91,7 +91,7 @@ EOS;
         unlink($tempFile);
 
         $this->assertEquals('Zend\Code\Generator\FileGenerator', get_class($fileGenerator));
-        $this->assertEquals(1, count($fileGenerator->getClasses()));
+        $this->assertCount(1, $fileGenerator->getClasses());
     }
 
     public function testFromFileReflection()

--- a/test/Generator/FileGeneratorTest.php
+++ b/test/Generator/FileGeneratorTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\Code\Generator;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Code\Generator\ClassGenerator;
 use Zend\Code\Generator\FileGenerator;
 use Zend\Code\Reflection\FileReflection;
@@ -18,7 +19,7 @@ use Zend\Code\Reflection\FileReflection;
  * @group Zend_Code_Generator_Php
  * @group Zend_Code_Generator_Php_File
  */
-class FileGeneratorTest extends \PHPUnit_Framework_TestCase
+class FileGeneratorTest extends TestCase
 {
     public function testConstruction()
     {

--- a/test/Generator/FileGeneratorTest.php
+++ b/test/Generator/FileGeneratorTest.php
@@ -24,7 +24,7 @@ class FileGeneratorTest extends TestCase
     public function testConstruction()
     {
         $file = new FileGenerator();
-        $this->assertEquals('Zend\Code\Generator\FileGenerator', get_class($file));
+        $this->assertEquals(FileGenerator::class, get_class($file));
     }
 
     public function testSourceContentGetterAndSetter()
@@ -78,8 +78,8 @@ EOS;
 
         $codeGenFile = FileGenerator::fromArray([
             'class' => [
-                'name' => 'SampleClass'
-            ]
+                'name' => 'SampleClass',
+            ],
         ]);
 
         file_put_contents($tempFile, $codeGenFile->generate());
@@ -90,7 +90,7 @@ EOS;
 
         unlink($tempFile);
 
-        $this->assertEquals('Zend\Code\Generator\FileGenerator', get_class($fileGenerator));
+        $this->assertEquals(FileGenerator::class, get_class($fileGenerator));
         $this->assertCount(1, $fileGenerator->getClasses());
     }
 
@@ -270,7 +270,7 @@ EOS;
             'class'     => new ClassGenerator('bar'),
         ]);
         $class = $fileGenerator->getClass('bar');
-        $this->assertInstanceOf('Zend\Code\Generator\ClassGenerator', $class);
+        $this->assertInstanceOf(ClassGenerator::class, $class);
     }
 
     public function testCreateFromArrayWithClassFromArray()
@@ -282,13 +282,13 @@ EOS;
             ],
         ]);
         $class = $fileGenerator->getClass('bar');
-        $this->assertInstanceOf('Zend\Code\Generator\ClassGenerator', $class);
+        $this->assertInstanceOf(ClassGenerator::class, $class);
     }
 
     public function testGeneratingFromAReflectedFileName()
     {
         $generator = FileGenerator::fromReflectedFileName(__DIR__ . '/TestAsset/OneInterface.php');
-        $this->assertInstanceOf('Zend\Code\Generator\FileGenerator', $generator);
+        $this->assertInstanceOf(FileGenerator::class, $generator);
     }
 
     public function testGeneratedClassesHaveUses()
@@ -296,7 +296,7 @@ EOS;
         $generator = FileGenerator::fromReflectedFileName(__DIR__ . '/TestAsset/ClassWithUses.php');
         $class = $generator->getClass();
 
-        $expectedUses = ['ZendTest\Code\Generator\TestAsset\ClassWithNamespace'];
+        $expectedUses = [TestAsset\ClassWithNamespace::class];
 
         $this->assertEquals($expectedUses, $class->getUses());
     }
@@ -306,7 +306,7 @@ EOS;
      */
     public function testIssue4747FileGenerationWithAddedMethodIsCorrectlyFormatted()
     {
-        $g = new \Zend\Code\Generator\FileGenerator();
+        $g = new FileGenerator();
         $g = $g->fromReflectedFileName(__DIR__ . '/TestAsset/ClassWithUses.php');
         $g->setFilename(sys_get_temp_dir() . '/result_class.php');
         $g->getClass()->addMethod('added');
@@ -351,11 +351,11 @@ CODE;
      */
     public function testCanAppendToBodyOfReflectedFile()
     {
-        $g = new \Zend\Code\Generator\FileGenerator();
+        $g = new FileGenerator();
         $g = $g->fromReflectedFileName(__DIR__ . '/TestAsset/ClassWithUses.php');
         $g->setFilename(sys_get_temp_dir() . '/result_class.php');
         $g->getClass()->addMethod('added');
-        $g->setBody("\$foo->bar();");
+        $g->setBody('$foo->bar();');
         $g->write();
 
         $expected = <<<'CODE'

--- a/test/Generator/InterfaceGeneratorTest.php
+++ b/test/Generator/InterfaceGeneratorTest.php
@@ -10,6 +10,7 @@
 namespace ZendTest\Code\Generator;
 
 use PHPUnit\Framework\TestCase;
+use Zend\Code\Generator\Exception\InvalidArgumentException;
 use Zend\Code\Generator\InterfaceGenerator;
 use Zend\Code\Generator\DocBlockGenerator;
 use Zend\Code\Generator\PropertyGenerator;
@@ -278,12 +279,10 @@ CODE;
         $this->assertEquals($expected, $output);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage Class ZendTest\Code\Generator\InterfaceGeneratorTest is not a interface
-     */
     public function testClassNotAnInterfaceException()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Class ZendTest\Code\Generator\InterfaceGeneratorTest is not a interface');
         InterfaceGenerator::fromReflection(new ClassReflection(__CLASS__));
     }
 }

--- a/test/Generator/InterfaceGeneratorTest.php
+++ b/test/Generator/InterfaceGeneratorTest.php
@@ -10,12 +10,13 @@
 namespace ZendTest\Code\Generator;
 
 use PHPUnit\Framework\TestCase;
+use Zend\Code\Generator\DocBlockGenerator;
 use Zend\Code\Generator\Exception\InvalidArgumentException;
 use Zend\Code\Generator\InterfaceGenerator;
-use Zend\Code\Generator\DocBlockGenerator;
-use Zend\Code\Generator\PropertyGenerator;
 use Zend\Code\Generator\MethodGenerator;
+use Zend\Code\Generator\PropertyGenerator;
 use Zend\Code\Reflection\ClassReflection;
+use ZendTest\Code\TestAsset\FooInterface;
 
 /**
  * @group Zend_Code_Generator
@@ -142,7 +143,7 @@ CODE;
      */
     public function testCodeGenerationShouldTakeIntoAccountNamespacesFromReflection()
     {
-        $reflClass      = new ClassReflection('ZendTest\Code\TestAsset\FooInterface');
+        $reflClass      = new ClassReflection(FooInterface::class);
         $classGenerator = InterfaceGenerator::fromReflection($reflClass);
 
         $this->assertEquals('ZendTest\Code\TestAsset', $classGenerator->getNamespaceName());
@@ -208,7 +209,7 @@ CODE;
         ]);
 
         $docBlock = $classGenerator->getDocBlock();
-        $this->assertInstanceOf('Zend\Code\Generator\DocBlockGenerator', $docBlock);
+        $this->assertInstanceOf(DocBlockGenerator::class, $docBlock);
     }
 
     public function testCreateFromArrayWithDocBlockInstance()
@@ -233,7 +234,7 @@ interface MyInterface
 
 CODE;
 
-        $this->assertInstanceOf('Zend\Code\Generator\DocBlockGenerator', $docBlock);
+        $this->assertInstanceOf(DocBlockGenerator::class, $docBlock);
         $this->assertEquals($expected, $output);
     }
 

--- a/test/Generator/InterfaceGeneratorTest.php
+++ b/test/Generator/InterfaceGeneratorTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\Code\Generator;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Code\Generator\InterfaceGenerator;
 use Zend\Code\Generator\DocBlockGenerator;
 use Zend\Code\Generator\PropertyGenerator;
@@ -19,7 +20,7 @@ use Zend\Code\Reflection\ClassReflection;
  * @group Zend_Code_Generator
  * @group Zend_Code_Generator_Php
  */
-class InterfaceGeneratorTest extends \PHPUnit_Framework_TestCase
+class InterfaceGeneratorTest extends TestCase
 {
     public function testAbstractAccessorsReturnsFalse()
     {

--- a/test/Generator/MethodGeneratorTest.php
+++ b/test/Generator/MethodGeneratorTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\Code\Generator;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Code\Generator\MethodGenerator;
 use Zend\Code\Generator\ParameterGenerator;
 use Zend\Code\Generator\ValueGenerator;
@@ -19,12 +20,13 @@ use ZendTest\Code\TestAsset\InternalHintsClass;
 use ZendTest\Code\TestAsset\IterableHintsClass;
 use ZendTest\Code\TestAsset\NullableReturnTypeHintedClass;
 use ZendTest\Code\TestAsset\ReturnTypeHintedClass;
+use Zend\Code\Generator\Exception\InvalidArgumentException;
 
 /**
  * @group Zend_Code_Generator
  * @group Zend_Code_Generator_Php
  */
-class MethodGeneratorTest extends \PHPUnit_Framework_TestCase
+class MethodGeneratorTest extends TestCase
 {
     public function testMethodConstructor()
     {
@@ -64,7 +66,7 @@ class MethodGeneratorTest extends \PHPUnit_Framework_TestCase
         $baz = array_shift($params);
         $this->assertEquals('baz', $baz->getName());
 
-        $this->setExpectedException('Zend\Code\Generator\Exception\InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
         $methodGenerator->setParameter(new \stdClass());
     }
 

--- a/test/Generator/MethodGeneratorTest.php
+++ b/test/Generator/MethodGeneratorTest.php
@@ -31,7 +31,7 @@ class MethodGeneratorTest extends TestCase
     public function testMethodConstructor()
     {
         $methodGenerator = new MethodGenerator();
-        $this->isInstanceOf($methodGenerator, '\Zend\Code\Generator\PhpMethod');
+        $this->assertInstanceOf(MethodGenerator::class, $methodGenerator);
     }
 
     public function testMethodParameterAccessors()

--- a/test/Generator/MethodGeneratorTest.php
+++ b/test/Generator/MethodGeneratorTest.php
@@ -297,7 +297,7 @@ CODE;
     }
 
 PHP;
-        self::assertSame($expected, $methodGenerator->generate());
+        $this->assertSame($expected, $methodGenerator->generate());
     }
 
     /**
@@ -316,7 +316,7 @@ PHP;
     }
 
 PHP;
-        self::assertSame($expected, $methodGenerator->generate());
+        $this->assertSame($expected, $methodGenerator->generate());
     }
 
     /**
@@ -332,7 +332,7 @@ PHP;
     {
         $methodGenerator = MethodGenerator::fromReflection(new MethodReflection($className, $methodName));
 
-        self::assertStringMatchesFormat('%A) : ' . $expectedReturnSignature . '%A{%A', $methodGenerator->generate());
+        $this->assertStringMatchesFormat('%A) : ' . $expectedReturnSignature . '%A{%A', $methodGenerator->generate());
     }
 
     public function returnTypeHintClassesProvider()
@@ -375,11 +375,11 @@ PHP;
 
         $methodGenerator->setReturnsReference(true);
 
-        self::assertStringMatchesFormat('%Apublic function & foo()%A', $methodGenerator->generate());
+        $this->assertStringMatchesFormat('%Apublic function & foo()%A', $methodGenerator->generate());
 
         $methodGenerator->setReturnsReference(false);
 
-        self::assertStringMatchesFormat('%Apublic function foo()%A', $methodGenerator->generate());
+        $this->assertStringMatchesFormat('%Apublic function foo()%A', $methodGenerator->generate());
     }
 
     /**
@@ -391,6 +391,6 @@ PHP;
             new MethodReflection(ClassWithByRefReturnMethod::class, 'byRefReturn')
         );
 
-        self::assertStringMatchesFormat('%Apublic function & byRefReturn()%A', $methodGenerator->generate());
+        $this->assertStringMatchesFormat('%Apublic function & byRefReturn()%A', $methodGenerator->generate());
     }
 }

--- a/test/Generator/MethodGeneratorTest.php
+++ b/test/Generator/MethodGeneratorTest.php
@@ -10,8 +10,12 @@
 namespace ZendTest\Code\Generator;
 
 use PHPUnit\Framework\TestCase;
+use stdClass;
+use Zend\Code\Generator\DocBlockGenerator;
+use Zend\Code\Generator\Exception\InvalidArgumentException;
 use Zend\Code\Generator\MethodGenerator;
 use Zend\Code\Generator\ParameterGenerator;
+use Zend\Code\Generator\TypeGenerator;
 use Zend\Code\Generator\ValueGenerator;
 use Zend\Code\Reflection\MethodReflection;
 use ZendTest\Code\TestAsset\ClassWithByRefReturnMethod;
@@ -20,7 +24,6 @@ use ZendTest\Code\TestAsset\InternalHintsClass;
 use ZendTest\Code\TestAsset\IterableHintsClass;
 use ZendTest\Code\TestAsset\NullableReturnTypeHintedClass;
 use ZendTest\Code\TestAsset\ReturnTypeHintedClass;
-use Zend\Code\Generator\Exception\InvalidArgumentException;
 
 /**
  * @group Zend_Code_Generator
@@ -40,7 +43,7 @@ class MethodGeneratorTest extends TestCase
         $methodGenerator->setParameters(['one']);
         $params = $methodGenerator->getParameters();
         $param = array_shift($params);
-        $this->assertInstanceOf('Zend\Code\Generator\ParameterGenerator', $param);
+        $this->assertInstanceOf(ParameterGenerator::class, $param);
     }
 
     public function testMethodParameterMutator()
@@ -49,14 +52,14 @@ class MethodGeneratorTest extends TestCase
 
         $methodGenerator->setParameter('foo');
         $methodGenerator->setParameter(['name' => 'bar', 'type' => 'array']);
-        $methodGenerator->setParameter(ParameterGenerator::fromArray(['name' => 'baz', 'type' => '\stdClass']));
+        $methodGenerator->setParameter(ParameterGenerator::fromArray(['name' => 'baz', 'type' => stdClass::class]));
 
         $params = $methodGenerator->getParameters();
         $this->assertCount(3, $params);
 
         /** @var $foo ParameterGenerator */
         $foo = array_shift($params);
-        $this->assertInstanceOf('Zend\Code\Generator\ParameterGenerator', $foo);
+        $this->assertInstanceOf(ParameterGenerator::class, $foo);
         $this->assertEquals('foo', $foo->getName());
 
         $bar = array_shift($params);
@@ -67,7 +70,7 @@ class MethodGeneratorTest extends TestCase
         $this->assertEquals('baz', $baz->getName());
 
         $this->expectException(InvalidArgumentException::class);
-        $methodGenerator->setParameter(new \stdClass());
+        $methodGenerator->setParameter(new stdClass());
     }
 
     public function testMethodBodyGetterAndSetter()
@@ -79,7 +82,7 @@ class MethodGeneratorTest extends TestCase
 
     public function testDocBlockGetterAndSetter()
     {
-        $docblockGenerator = new \Zend\Code\Generator\DocBlockGenerator();
+        $docblockGenerator = new DocBlockGenerator();
 
         $method = new MethodGenerator();
         $method->setDocBlock($docblockGenerator);
@@ -89,7 +92,7 @@ class MethodGeneratorTest extends TestCase
 
     public function testMethodFromReflection()
     {
-        $ref = new MethodReflection('ZendTest\Code\Generator\TestAsset\TestSampleSingleClass', 'someMethod');
+        $ref = new MethodReflection(TestAsset\TestSampleSingleClass::class, 'someMethod');
 
         $methodGenerator = MethodGenerator::fromReflection($ref);
         $target = <<<EOS
@@ -110,7 +113,7 @@ EOS;
 
     public function testMethodFromReflectionMultiLinesIndention()
     {
-        $ref = new MethodReflection('ZendTest\Code\Generator\TestAsset\TestSampleSingleClassMultiLines', 'someMethod');
+        $ref = new MethodReflection(TestAsset\TestSampleSingleClassMultiLines::class, 'someMethod');
 
         $methodGenerator = MethodGenerator::fromReflection($ref);
         $target = <<<EOS
@@ -227,7 +230,7 @@ EOS;
 
         $method->setParameter($param);
         $generated = $method->generate();
-        $this->assertRegexp('/array \$options = array\(\)\)/', $generated, $generated);
+        $this->assertRegExp('/array \$options = array\(\)\)/', $generated, $generated);
     }
 
     public function testCreateFromArray()
@@ -247,12 +250,12 @@ EOS;
 
         $this->assertEquals('SampleMethod', $methodGenerator->getName());
         $this->assertEquals('foo', $methodGenerator->getBody());
-        $this->assertInstanceOf('Zend\Code\Generator\DocBlockGenerator', $methodGenerator->getDocBlock());
+        $this->assertInstanceOf(DocBlockGenerator::class, $methodGenerator->getDocBlock());
         $this->assertTrue($methodGenerator->isAbstract());
         $this->assertTrue($methodGenerator->isFinal());
         $this->assertTrue($methodGenerator->isStatic());
         $this->assertEquals(MethodGenerator::VISIBILITY_PROTECTED, $methodGenerator->getVisibility());
-        $this->assertInstanceOf('Zend\Code\Generator\TypeGenerator', $methodGenerator->getReturnType());
+        $this->assertInstanceOf(TypeGenerator::class, $methodGenerator->getReturnType());
         $this->assertEquals('\\SampleType', $methodGenerator->getReturnType()->generate());
     }
 
@@ -278,7 +281,7 @@ CODE;
         $this->assertTrue($methodGenerator->isInterface());
         $this->assertEquals('execute', $methodGenerator->getName());
         $this->assertEquals($expected, $methodGenerator->generate());
-        $this->assertInstanceOf('Zend\Code\Generator\DocBlockGenerator', $methodGenerator->getDocBlock());
+        $this->assertInstanceOf(DocBlockGenerator::class, $methodGenerator->getDocBlock());
     }
 
     /**

--- a/test/Generator/MethodGeneratorTest.php
+++ b/test/Generator/MethodGeneratorTest.php
@@ -283,8 +283,6 @@ CODE;
 
     /**
      * @group zendframework/zend-code#29
-     *
-     * @requires PHP 7.0
      */
     public function testSetReturnType()
     {
@@ -304,8 +302,6 @@ PHP;
 
     /**
      * @group zendframework/zend-code#29
-     *
-     * @requires PHP 7.0
      */
     public function testSetReturnTypeWithNull()
     {
@@ -325,8 +321,6 @@ PHP;
 
     /**
      * @group zendframework/zend-code#29
-     *
-     * @requires PHP 7.0
      *
      * @dataProvider returnTypeHintClassesProvider
      *
@@ -369,16 +363,7 @@ PHP;
             [IterableHintsClass::class, 'nullableIterableReturnValue', '?iterable'],
         ];
 
-        return array_filter(
-            $parameters,
-            function (array $parameter) {
-                return PHP_VERSION_ID >= 70100
-                    || (
-                        false === strpos($parameter[2], '?')
-                        && ! in_array(strtolower($parameter[2]), ['void', 'iterable'])
-                    );
-            }
-        );
+        return $parameters;
     }
 
     /**

--- a/test/Generator/ParameterGeneratorTest.php
+++ b/test/Generator/ParameterGeneratorTest.php
@@ -281,7 +281,7 @@ class ParameterGeneratorTest extends TestCase
         $parameter->setName('foo');
         $parameter->setType($type);
 
-        self::assertSame($expectedType . ' $foo', $parameter->generate());
+        $this->assertSame($expectedType . ' $foo', $parameter->generate());
     }
 
     /**
@@ -325,7 +325,7 @@ class ParameterGeneratorTest extends TestCase
         $parameter->setName('foo');
         $parameter->setType($className);
 
-        self::assertSame('\\' . $className . ' $foo', $parameter->generate());
+        $this->assertSame('\\' . $className . ' $foo', $parameter->generate());
     }
 
     /**
@@ -373,12 +373,12 @@ class ParameterGeneratorTest extends TestCase
         ));
 
         if (null === $expectedType) {
-            self::assertNull($parameter->getType());
+            $this->assertNull($parameter->getType());
 
             return;
         }
 
-        self::assertSame(ltrim($expectedType, '?\\'), $parameter->getType());
+        $this->assertSame(ltrim($expectedType, '?\\'), $parameter->getType());
     }
 
     /**
@@ -399,12 +399,12 @@ class ParameterGeneratorTest extends TestCase
         ));
 
         if (null === $expectedType) {
-            self::assertStringStartsWith('$' . $parameterName, $parameter->generate());
+            $this->assertStringStartsWith('$' . $parameterName, $parameter->generate());
 
             return;
         }
 
-        self::assertStringStartsWith($expectedType . ' $' . $parameterName, $parameter->generate());
+        $this->assertStringStartsWith($expectedType . ' $' . $parameterName, $parameter->generate());
     }
 
     /**
@@ -500,8 +500,8 @@ class ParameterGeneratorTest extends TestCase
             $parameterName
         ));
 
-        self::assertTrue($parameter->getVariadic());
-        self::assertSame($expectedGeneratedSignature, $parameter->generate());
+        $this->assertTrue($parameter->getVariadic());
+        $this->assertSame($expectedGeneratedSignature, $parameter->generate());
     }
 
     /**
@@ -545,18 +545,18 @@ class ParameterGeneratorTest extends TestCase
     {
         $parameter = new ParameterGenerator('foo');
 
-        self::assertFalse($parameter->getVariadic(), 'Is not variadic by default');
-        self::assertSame('$foo', $parameter->generate());
+        $this->assertFalse($parameter->getVariadic(), 'Is not variadic by default');
+        $this->assertSame('$foo', $parameter->generate());
 
         $parameter->setVariadic(true);
 
-        self::assertTrue($parameter->getVariadic());
-        self::assertSame('... $foo', $parameter->generate());
+        $this->assertTrue($parameter->getVariadic());
+        $this->assertSame('... $foo', $parameter->generate());
 
         $parameter->setVariadic(false);
 
-        self::assertFalse($parameter->getVariadic());
-        self::assertSame('$foo', $parameter->generate());
+        $this->assertFalse($parameter->getVariadic());
+        $this->assertSame('$foo', $parameter->generate());
     }
 
     /**

--- a/test/Generator/ParameterGeneratorTest.php
+++ b/test/Generator/ParameterGeneratorTest.php
@@ -269,8 +269,6 @@ class ParameterGeneratorTest extends TestCase
     /**
      * @group zendframework/zend-code#29
      *
-     * @requires PHP 7.0
-     *
      * @dataProvider simpleHintsProvider
      *
      * @param string $type
@@ -316,8 +314,6 @@ class ParameterGeneratorTest extends TestCase
     /**
      * @group zendframework/zend-code#29
      *
-     * @requires PHP 7.0
-     *
      * @dataProvider validClassNameProvider
      *
      * @param string $className
@@ -362,8 +358,6 @@ class ParameterGeneratorTest extends TestCase
     /**
      * @group zendframework/zend-code#29
      *
-     * @requires PHP 7.0
-     *
      * @dataProvider reflectionHintsProvider
      *
      * @param string      $className
@@ -389,8 +383,6 @@ class ParameterGeneratorTest extends TestCase
 
     /**
      * @group zendframework/zend-code#29
-     *
-     * @requires PHP 7.0
      *
      * @dataProvider reflectionHintsProvider
      *
@@ -475,30 +467,20 @@ class ParameterGeneratorTest extends TestCase
             [IterableHintsClass::class, 'nullDefaultIterableParameter', 'foo', '?iterable'],
         ];
 
-        $compatibleParameters = array_filter(
-            $parameters,
-            function (array $parameter) {
-                return PHP_VERSION_ID >= 70100
-                    || (false === strpos($parameter[3], '?') && 'iterable' !== strtolower($parameter[3]));
-            }
-        );
-
         // just re-organizing the keys so that the phpunit data set makes sense in errors:
         return array_combine(
             array_map(
                 function (array $definition) {
                     return $definition[0] . '#' . $definition[1];
                 },
-                $compatibleParameters
+                $parameters
             ),
-            $compatibleParameters
+            $parameters
         );
     }
 
     /**
      * @group zendframework/zend-code#29
-     *
-     * @requires PHP 7.0
      *
      * @dataProvider variadicHintsProvider
      *
@@ -553,8 +535,6 @@ class ParameterGeneratorTest extends TestCase
 
     /**
      * @group zendframework/zend-code#29
-     *
-     * @requires PHP 5.6
      *
      * @param string $className
      * @param string $methodName

--- a/test/Generator/ParameterGeneratorTest.php
+++ b/test/Generator/ParameterGeneratorTest.php
@@ -12,6 +12,7 @@ namespace ZendTest\Code\Generator;
 use PHPUnit\Framework\TestCase;
 use Zend\Code\Generator\ParameterGenerator;
 use Zend\Code\Generator\ValueGenerator;
+use Zend\Code\Reflection\ClassReflection;
 use Zend\Code\Reflection\MethodReflection;
 use Zend\Code\Reflection\ParameterReflection;
 use ZendTest\Code\Generator\TestAsset\ParameterClass;
@@ -141,7 +142,7 @@ class ParameterGeneratorTest extends TestCase
     public function testCallableTypeHint()
     {
         $parameter = ParameterGenerator::fromReflection(
-            new ParameterReflection(['ZendTest\Code\Generator\TestAsset\CallableTypeHintClass', 'foo'], 'bar')
+            new ParameterReflection([TestAsset\CallableTypeHintClass::class, 'foo'], 'bar')
         );
 
         $this->assertEquals('callable', $parameter->getType());
@@ -182,14 +183,12 @@ class ParameterGeneratorTest extends TestCase
     }
 
     /**
-     * @param  string                               $method
-     * @return \Zend\Code\Reflection\ParameterReflection
+     * @param  string $method
+     * @return ParameterReflection
      */
     protected function getFirstReflectionParameter($method)
     {
-        $reflectionClass = new \Zend\Code\Reflection\ClassReflection(
-            'ZendTest\Code\Generator\TestAsset\ParameterClass'
-        );
+        $reflectionClass = new ClassReflection(TestAsset\ParameterClass::class);
         $method = $reflectionClass->getMethod($method);
 
         $params = $method->getParameters();
@@ -212,7 +211,7 @@ class ParameterGeneratorTest extends TestCase
 
         $this->assertEquals('SampleParameter', $parameterGenerator->getName());
         $this->assertEquals('int', $parameterGenerator->getType());
-        $this->assertInstanceOf('Zend\Code\Generator\ValueGenerator', $parameterGenerator->getDefaultValue());
+        $this->assertInstanceOf(ValueGenerator::class, $parameterGenerator->getDefaultValue());
         $this->assertFalse($parameterGenerator->getPassedByReference());
         $this->assertEquals(1, $parameterGenerator->getPosition());
         $this->assertFalse($parameterGenerator->isSourceDirty());
@@ -227,7 +226,7 @@ class ParameterGeneratorTest extends TestCase
     {
         require_once __DIR__ . '/../TestAsset/NonNamespaceClass.php';
 
-        $reflClass = new \Zend\Code\Reflection\ClassReflection('ZendTest_Code_NsTest_BarClass');
+        $reflClass = new ClassReflection('ZendTest_Code_NsTest_BarClass');
         $params = $reflClass->getMethod('fooMethod')->getParameters();
 
         $param = ParameterGenerator::fromReflection($params[0]);
@@ -242,7 +241,7 @@ class ParameterGeneratorTest extends TestCase
     {
         require_once __DIR__ . '/TestAsset/NamespaceTypeHintClass.php';
 
-        $reflClass = new \Zend\Code\Reflection\ClassReflection('Namespaced\TypeHint\Bar');
+        $reflClass = new ClassReflection('Namespaced\TypeHint\Bar');
         $params = $reflClass->getMethod('method')->getParameters();
 
         $param = ParameterGenerator::fromReflection($params[0]);
@@ -535,11 +534,6 @@ class ParameterGeneratorTest extends TestCase
 
     /**
      * @group zendframework/zend-code#29
-     *
-     * @param string $className
-     * @param string $methodName
-     * @param string $parameterName
-     * @param string $expectedGeneratedSignature
      */
     public function testSetGetVariadic()
     {

--- a/test/Generator/ParameterGeneratorTest.php
+++ b/test/Generator/ParameterGeneratorTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\Code\Generator;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Code\Generator\ParameterGenerator;
 use Zend\Code\Generator\ValueGenerator;
 use Zend\Code\Reflection\MethodReflection;
@@ -27,7 +28,7 @@ use ZendTest\Code\TestAsset\VariadicParametersClass;
  * @group Zend_Code_Generator
  * @group Zend_Code_Generator_Php
  */
-class ParameterGeneratorTest extends \PHPUnit_Framework_TestCase
+class ParameterGeneratorTest extends TestCase
 {
     public function testTypeGetterAndSetterPersistValue()
     {

--- a/test/Generator/PropertyGeneratorTest.php
+++ b/test/Generator/PropertyGeneratorTest.php
@@ -9,15 +9,17 @@
 
 namespace ZendTest\Code\Generator;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Code\Generator\PropertyGenerator;
 use Zend\Code\Generator\PropertyValueGenerator;
 use Zend\Code\Reflection\ClassReflection;
+use Zend\Code\Generator\Exception\RuntimeException;
 
 /**
  * @group Zend_Code_Generator
  * @group Zend_Code_Generator_Php
  */
-class PropertyGeneratorTest extends \PHPUnit_Framework_TestCase
+class PropertyGeneratorTest extends TestCase
 {
     public function testPropertyConstructor()
     {
@@ -206,10 +208,8 @@ EOS;
     {
         $codeGenProperty = new PropertyGenerator('someVal', new \stdClass());
 
-        $this->setExpectedException(
-            'Zend\Code\Generator\Exception\RuntimeException',
-            'Type "stdClass" is unknown or cannot be used as property default value'
-        );
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Type "stdClass" is unknown or cannot be used as property default value');
 
         $codeGenProperty->generate();
     }

--- a/test/Generator/PropertyGeneratorTest.php
+++ b/test/Generator/PropertyGeneratorTest.php
@@ -24,7 +24,7 @@ class PropertyGeneratorTest extends TestCase
     public function testPropertyConstructor()
     {
         $codeGenProperty = new PropertyGenerator();
-        $this->isInstanceOf($codeGenProperty, 'Zend\Code\Generator\PropertyGenerator');
+        $this->assertInstanceOf(PropertyGenerator::class, $codeGenProperty);
     }
 
     /**
@@ -255,7 +255,7 @@ EOS;
         $this->assertInstanceOf('Zend\Code\Generator\DocBlockGenerator', $docBlock);
         $tags     = $docBlock->getTags();
         $this->assertInternalType('array', $tags);
-        $this->assertEquals(1, count($tags));
+        $this->assertCount(1, $tags);
         $tag = array_shift($tags);
         $this->assertInstanceOf('Zend\Code\Generator\DocBlock\Tag\GenericTag', $tag);
         $this->assertEquals('var', $tag->getName());

--- a/test/Generator/PropertyGeneratorTest.php
+++ b/test/Generator/PropertyGeneratorTest.php
@@ -10,10 +10,13 @@
 namespace ZendTest\Code\Generator;
 
 use PHPUnit\Framework\TestCase;
+use Zend\Code\Generator\DocBlock\Tag\GenericTag;
+use Zend\Code\Generator\DocBlockGenerator;
+use Zend\Code\Generator\Exception\RuntimeException;
 use Zend\Code\Generator\PropertyGenerator;
 use Zend\Code\Generator\PropertyValueGenerator;
+use Zend\Code\Generator\ValueGenerator;
 use Zend\Code\Reflection\ClassReflection;
-use Zend\Code\Generator\Exception\RuntimeException;
 
 /**
  * @group Zend_Code_Generator
@@ -34,11 +37,11 @@ class PropertyGeneratorTest extends TestCase
     {
         return [
             ['string', 'foo', "'foo';"],
-            ['int', 1, "1;"],
-            ['integer', 1, "1;"],
-            ['bool', true, "true;"],
-            ['bool', false, "false;"],
-            ['boolean', true, "true;"],
+            ['int', 1, '1;'],
+            ['integer', 1, '1;'],
+            ['bool', true, 'true;'],
+            ['bool', false, 'false;'],
+            ['boolean', true, 'true;'],
             ['number', 1, '1;'],
             ['float', 1.23, '1.23;'],
             ['double', 1.23, '1.23;'],
@@ -76,7 +79,7 @@ class PropertyGeneratorTest extends TestCase
         }
 
         $defaultValue = new PropertyValueGenerator();
-        $defaultValue->setType("bogus");
+        $defaultValue->setType('bogus');
         $defaultValue->setValue($value);
 
         $this->assertEquals($code, $defaultValue->generate());
@@ -145,9 +148,7 @@ EOS;
      */
     public function testPropertyWillLoadFromReflection()
     {
-        $reflectionClass = new \Zend\Code\Reflection\ClassReflection(
-            '\ZendTest\Code\Generator\TestAsset\TestClassWithManyProperties'
-        );
+        $reflectionClass = new ClassReflection(TestAsset\TestClassWithManyProperties::class);
 
         // test property 1
         $reflProp = $reflectionClass->getProperty('_bazProperty');
@@ -231,8 +232,8 @@ EOS;
 
         $this->assertEquals('SampleProperty', $propertyGenerator->getName());
         $this->assertTrue($propertyGenerator->isConst());
-        $this->assertInstanceOf('Zend\Code\Generator\ValueGenerator', $propertyGenerator->getDefaultValue());
-        $this->assertInstanceOf('Zend\Code\Generator\DocBlockGenerator', $propertyGenerator->getDocBlock());
+        $this->assertInstanceOf(ValueGenerator::class, $propertyGenerator->getDefaultValue());
+        $this->assertInstanceOf(DocBlockGenerator::class, $propertyGenerator->getDocBlock());
         $this->assertTrue($propertyGenerator->isAbstract());
         $this->assertTrue($propertyGenerator->isFinal());
         $this->assertTrue($propertyGenerator->isStatic());
@@ -252,12 +253,12 @@ EOS;
         $this->assertEquals('fooProperty', $cgProp->getName());
 
         $docBlock = $cgProp->getDocBlock();
-        $this->assertInstanceOf('Zend\Code\Generator\DocBlockGenerator', $docBlock);
+        $this->assertInstanceOf(DocBlockGenerator::class, $docBlock);
         $tags     = $docBlock->getTags();
         $this->assertInternalType('array', $tags);
         $this->assertCount(1, $tags);
         $tag = array_shift($tags);
-        $this->assertInstanceOf('Zend\Code\Generator\DocBlock\Tag\GenericTag', $tag);
+        $this->assertInstanceOf(GenericTag::class, $tag);
         $this->assertEquals('var', $tag->getName());
     }
 

--- a/test/Generator/PropertyValueGeneratorTest.php
+++ b/test/Generator/PropertyValueGeneratorTest.php
@@ -9,13 +9,14 @@
 
 namespace ZendTest\Code\Generator;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Code\Generator\PropertyValueGenerator;
 
 /**
  * @group Zend_Code_Generator
  * @group Zend_Code_Generator_Php
  */
-class PropertyValueGeneratorTest extends \PHPUnit_Framework_TestCase
+class PropertyValueGeneratorTest extends TestCase
 {
     public function testPropertyValueAddsSemicolonToValueGenerator()
     {

--- a/test/Generator/TestAsset/ParameterClass.php
+++ b/test/Generator/TestAsset/ParameterClass.php
@@ -26,7 +26,7 @@ class ParameterClass
 
     }
 
-    public function defaultValue($value = "foo")
+    public function defaultValue($value = 'foo')
     {
     }
 
@@ -75,7 +75,7 @@ class ParameterClass
 
     }
 
-    const FOO = "foo";
+    const FOO = 'foo';
 
     public function defaultConstant($con = self::FOO)
     {

--- a/test/Generator/TraitGeneratorTest.php
+++ b/test/Generator/TraitGeneratorTest.php
@@ -9,17 +9,20 @@
 
 namespace ZendTest\Code\Generator;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Code\Generator\TraitGenerator;
 use Zend\Code\Generator\DocBlockGenerator;
 use Zend\Code\Generator\PropertyGenerator;
 use Zend\Code\Generator\MethodGenerator;
 use Zend\Code\Reflection\ClassReflection;
+use Zend\Code\Generator\Exception\InvalidArgumentException;
+use Zend\Code\Generator\Exception\ExceptionInterface;
 
 /**
  * @group Zend_Code_Generator
  * @group Zend_Code_Generator_Php
  */
-class TraitGeneratorTest extends \PHPUnit_Framework_TestCase
+class TraitGeneratorTest extends TestCase
 {
     public function setUp()
     {
@@ -91,10 +94,8 @@ class TraitGeneratorTest extends \PHPUnit_Framework_TestCase
         $classGenerator = new TraitGenerator();
         $classGenerator->addProperty('prop3');
 
-        $this->setExpectedException(
-            'Zend\Code\Generator\Exception\InvalidArgumentException',
-            'A property by name prop3 already exists in this class'
-        );
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('A property by name prop3 already exists in this class');
         $classGenerator->addProperty('prop3');
     }
 
@@ -102,10 +103,8 @@ class TraitGeneratorTest extends \PHPUnit_Framework_TestCase
     {
         $classGenerator = new TraitGenerator();
 
-        $this->setExpectedException(
-            'Zend\Code\Generator\Exception\InvalidArgumentException',
-            'Zend\Code\Generator\TraitGenerator::addProperty expects string for name'
-        );
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Zend\Code\Generator\TraitGenerator::addProperty expects string for name');
         $classGenerator->addProperty(true);
     }
 
@@ -134,10 +133,8 @@ class TraitGeneratorTest extends \PHPUnit_Framework_TestCase
     {
         $classGenerator = new TraitGenerator();
 
-        $this->setExpectedException(
-            'Zend\Code\Generator\Exception\ExceptionInterface',
-            'Zend\Code\Generator\TraitGenerator::addMethod expects string for name'
-        );
+        $this->expectException(ExceptionInterface::class);
+        $this->expectExceptionMessage('Zend\Code\Generator\TraitGenerator::addMethod expects string for name');
 
         $classGenerator->addMethod(true);
     }
@@ -152,10 +149,8 @@ class TraitGeneratorTest extends \PHPUnit_Framework_TestCase
         $classGenerator = new TraitGenerator();
         $classGenerator->addMethodFromGenerator($methodA);
 
-        $this->setExpectedException(
-            'Zend\Code\Generator\Exception\InvalidArgumentException',
-            'A method by name foo already exists in this class.'
-        );
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('A method by name foo already exists in this class.');
 
         $classGenerator->addMethodFromGenerator($methodB);
     }

--- a/test/Generator/TraitGeneratorTest.php
+++ b/test/Generator/TraitGeneratorTest.php
@@ -10,13 +10,13 @@
 namespace ZendTest\Code\Generator;
 
 use PHPUnit\Framework\TestCase;
-use Zend\Code\Generator\TraitGenerator;
 use Zend\Code\Generator\DocBlockGenerator;
-use Zend\Code\Generator\PropertyGenerator;
-use Zend\Code\Generator\MethodGenerator;
-use Zend\Code\Reflection\ClassReflection;
-use Zend\Code\Generator\Exception\InvalidArgumentException;
 use Zend\Code\Generator\Exception\ExceptionInterface;
+use Zend\Code\Generator\Exception\InvalidArgumentException;
+use Zend\Code\Generator\MethodGenerator;
+use Zend\Code\Generator\PropertyGenerator;
+use Zend\Code\Generator\TraitGenerator;
+use Zend\Code\Reflection\ClassReflection;
 
 /**
  * @group Zend_Code_Generator
@@ -78,10 +78,10 @@ class TraitGeneratorTest extends TestCase
 
         $properties = $classGenerator->getProperties();
         $this->assertCount(2, $properties);
-        $this->assertInstanceOf('Zend\Code\Generator\PropertyGenerator', current($properties));
+        $this->assertInstanceOf(PropertyGenerator::class, current($properties));
 
         $property = $classGenerator->getProperty('propTwo');
-        $this->assertInstanceOf('Zend\Code\Generator\PropertyGenerator', $property);
+        $this->assertInstanceOf(PropertyGenerator::class, $property);
         $this->assertEquals($property->getName(), 'propTwo');
 
         // add a new property
@@ -142,9 +142,9 @@ class TraitGeneratorTest extends TestCase
     public function testSetMethodNameAlreadyExistsThrowsException()
     {
         $methodA = new MethodGenerator();
-        $methodA->setName("foo");
+        $methodA->setName('foo');
         $methodB = new MethodGenerator();
-        $methodB->setName("foo");
+        $methodB->setName('foo');
 
         $classGenerator = new TraitGenerator();
         $classGenerator->addMethodFromGenerator($methodA);
@@ -192,10 +192,10 @@ class TraitGeneratorTest extends TestCase
         $classGenerator = TraitGenerator::fromArray([
             'name' => 'SampleClass',
             'properties' => ['foo',
-                ['name' => 'bar']
+                ['name' => 'bar'],
             ],
             'methods' => [
-                ['name' => 'baz']
+                ['name' => 'baz'],
             ],
         ]);
 
@@ -225,7 +225,7 @@ EOS;
      */
     public function testClassFromReflectionThatImplementsInterfaces()
     {
-        $reflClass = new ClassReflection('ZendTest\Code\Generator\TestAsset\ClassWithInterface');
+        $reflClass = new ClassReflection(TestAsset\ClassWithInterface::class);
 
         $classGenerator = TraitGenerator::fromReflection($reflClass);
         $classGenerator->setSourceDirty(true);
@@ -241,7 +241,7 @@ EOS;
      */
     public function testClassFromReflectionDiscardParentImplementedInterfaces()
     {
-        $reflClass = new ClassReflection('ZendTest\Code\Generator\TestAsset\NewClassWithInterface');
+        $reflClass = new ClassReflection(TestAsset\NewClassWithInterface::class);
 
         $classGenerator = TraitGenerator::fromReflection($reflClass);
         $classGenerator->setSourceDirty(true);
@@ -311,7 +311,7 @@ CODE;
      */
     public function testCodeGenerationShouldTakeIntoAccountNamespacesFromReflection()
     {
-        $reflClass = new ClassReflection('ZendTest\Code\Generator\TestAsset\ClassWithNamespace');
+        $reflClass = new ClassReflection(TestAsset\ClassWithNamespace::class);
         $classGenerator = TraitGenerator::fromReflection($reflClass);
         $this->assertEquals('ZendTest\Code\Generator\TestAsset', $classGenerator->getNamespaceName());
         $this->assertEquals('ClassWithNamespace', $classGenerator->getName());
@@ -418,7 +418,7 @@ CODE;
         ]);
 
         $docBlock = $classGenerator->getDocBlock();
-        $this->assertInstanceOf('Zend\Code\Generator\DocBlockGenerator', $docBlock);
+        $this->assertInstanceOf(DocBlockGenerator::class, $docBlock);
     }
 
     public function testCreateFromArrayWithDocBlockInstance()
@@ -429,12 +429,12 @@ CODE;
         ]);
 
         $docBlock = $classGenerator->getDocBlock();
-        $this->assertInstanceOf('Zend\Code\Generator\DocBlockGenerator', $docBlock);
+        $this->assertInstanceOf(DocBlockGenerator::class, $docBlock);
     }
 
     public function testExtendedClassProperies()
     {
-        $reflClass = new ClassReflection('ZendTest\Code\Generator\TestAsset\ExtendedClassWithProperties');
+        $reflClass = new ClassReflection(TestAsset\ExtendedClassWithProperties::class);
         $classGenerator = TraitGenerator::fromReflection($reflClass);
         $code = $classGenerator->generate();
         $this->assertContains('publicExtendedClassProperty', $code);

--- a/test/Generator/TraitGeneratorTest.php
+++ b/test/Generator/TraitGeneratorTest.php
@@ -31,7 +31,7 @@ class TraitGeneratorTest extends TestCase
     public function testConstruction()
     {
         $class = new TraitGenerator();
-        $this->isInstanceOf($class, 'Zend\Code\Generator\TraitGenerator');
+        $this->assertInstanceOf(TraitGenerator::class, $class);
     }
 
     public function testNameAccessors()
@@ -65,7 +65,7 @@ class TraitGeneratorTest extends TestCase
     {
         $classGenerator = new TraitGenerator();
         $classGenerator->setImplementedInterfaces(['Class1', 'Class2']);
-        $this->assertEquals(count($classGenerator->getImplementedInterfaces()), 0);
+        $this->assertCount(0, $classGenerator->getImplementedInterfaces());
     }
 
     public function testPropertyAccessors()
@@ -77,7 +77,7 @@ class TraitGeneratorTest extends TestCase
         ]);
 
         $properties = $classGenerator->getProperties();
-        $this->assertEquals(count($properties), 2);
+        $this->assertCount(2, $properties);
         $this->assertInstanceOf('Zend\Code\Generator\PropertyGenerator', current($properties));
 
         $property = $classGenerator->getProperty('propTwo');
@@ -86,7 +86,7 @@ class TraitGeneratorTest extends TestCase
 
         // add a new property
         $classGenerator->addProperty('prop3');
-        $this->assertEquals(count($classGenerator->getProperties()), 3);
+        $this->assertCount(3, $classGenerator->getProperties());
     }
 
     public function testSetPropertyAlreadyExistsThrowsException()
@@ -117,16 +117,16 @@ class TraitGeneratorTest extends TestCase
         ]);
 
         $methods = $classGenerator->getMethods();
-        $this->assertEquals(count($methods), 2);
-        $this->isInstanceOf(current($methods), '\Zend\Code\Generator\PhpMethod');
+        $this->assertCount(2, $methods);
+        $this->assertInstanceOf(MethodGenerator::class, current($methods));
 
         $method = $classGenerator->getMethod('methodOne');
-        $this->isInstanceOf($method, '\Zend\Code\Generator\PhpMethod');
+        $this->assertInstanceOf(MethodGenerator::class, $method);
         $this->assertEquals($method->getName(), 'methodOne');
 
         // add a new property
         $classGenerator->addMethod('methodThree');
-        $this->assertEquals(count($classGenerator->getMethods()), 3);
+        $this->assertCount(3, $classGenerator->getMethods());
     }
 
     public function testSetMethodNoMethodOrArrayThrowsException()

--- a/test/Generator/TypeGeneratorTest.php
+++ b/test/Generator/TypeGeneratorTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\Code\Generator;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Code\Exception\InvalidArgumentException;
 use Zend\Code\Generator\GeneratorInterface;
 use Zend\Code\Generator\TypeGenerator;
@@ -20,7 +21,7 @@ use Zend\Code\Generator\TypeGenerator;
  *
  * @covers \Zend\Code\Generator\TypeGenerator
  */
-class TypeGeneratorTest extends \PHPUnit_Framework_TestCase
+class TypeGeneratorTest extends TestCase
 {
     public function testIsAGenerator()
     {
@@ -74,7 +75,7 @@ class TypeGeneratorTest extends \PHPUnit_Framework_TestCase
      */
     public function testRejectsInvalidTypeString(string $typeString)
     {
-        $this->setExpectedException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         TypeGenerator::fromTypeString($typeString);
     }

--- a/test/Generator/TypeGeneratorTest.php
+++ b/test/Generator/TypeGeneratorTest.php
@@ -23,7 +23,7 @@ class TypeGeneratorTest extends TestCase
 {
     public function testIsAGenerator()
     {
-        self::assertContains(GeneratorInterface::class, class_implements(TypeGenerator::class));
+        $this->assertContains(GeneratorInterface::class, class_implements(TypeGenerator::class));
     }
 
     /**
@@ -36,7 +36,7 @@ class TypeGeneratorTest extends TestCase
     {
         $generator = TypeGenerator::fromTypeString($typeString);
 
-        self::assertSame($expectedReturnType, $generator->generate());
+        $this->assertSame($expectedReturnType, $generator->generate());
     }
 
     /**
@@ -49,7 +49,7 @@ class TypeGeneratorTest extends TestCase
     {
         $generator = TypeGenerator::fromTypeString($typeString);
 
-        self::assertSame(ltrim($expectedReturnType, '?\\'), (string) $generator);
+        $this->assertSame(ltrim($expectedReturnType, '?\\'), (string) $generator);
     }
 
     /**
@@ -62,8 +62,8 @@ class TypeGeneratorTest extends TestCase
     {
         $generator = TypeGenerator::fromTypeString('\\' . $typeString);
 
-        self::assertSame($expectedReturnType, $generator->generate());
-        self::assertSame(ltrim($expectedReturnType, '\\'), (string) $generator);
+        $this->assertSame($expectedReturnType, $generator->generate());
+        $this->assertSame(ltrim($expectedReturnType, '\\'), (string) $generator);
     }
 
     /**

--- a/test/Generator/TypeGeneratorTest.php
+++ b/test/Generator/TypeGeneratorTest.php
@@ -17,8 +17,6 @@ use Zend\Code\Generator\TypeGenerator;
 /**
  * @group zendframework/zend-code#29
  *
- * @requires PHP 7.0
- *
  * @covers \Zend\Code\Generator\TypeGenerator
  */
 class TypeGeneratorTest extends TestCase

--- a/test/Generator/ValueGeneratorTest.php
+++ b/test/Generator/ValueGeneratorTest.php
@@ -11,6 +11,7 @@ namespace ZendTest\Code\Generator;
 
 use ArrayAccess;
 use ArrayObject as SplArrayObject;
+use PHPUnit\Framework\TestCase;
 use Zend\Code\Exception\InvalidArgumentException;
 use Zend\Code\Generator\PropertyGenerator;
 use Zend\Code\Generator\PropertyValueGenerator;
@@ -23,7 +24,7 @@ use Zend\Code\Generator\ValueGenerator;
  *
  * @covers \Zend\Code\Generator\ValueGenerator
  */
-class ValueGeneratorTest extends \PHPUnit_Framework_TestCase
+class ValueGeneratorTest extends TestCase
 {
     public function testDefaultInstance()
     {
@@ -34,12 +35,10 @@ class ValueGeneratorTest extends \PHPUnit_Framework_TestCase
 
     public function testInvalidConstantsType()
     {
-        $this->setExpectedException(
-            InvalidArgumentException::class,
-            '$constants must be an instance of ArrayObject or Zend\Stdlib\ArrayObject'
-        );
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('$constants must be an instance of ArrayObject or Zend\Stdlib\ArrayObject');
 
-        $constants = $this->getMock(ArrayAccess::class);
+        $constants = $this->createMock(ArrayAccess::class);
         new ValueGenerator(null, ValueGenerator::TYPE_AUTO, ValueGenerator::OUTPUT_MULTIPLE_LINE, $constants);
     }
 

--- a/test/Generator/ValueGeneratorTest.php
+++ b/test/Generator/ValueGeneratorTest.php
@@ -15,8 +15,8 @@ use PHPUnit\Framework\TestCase;
 use Zend\Code\Exception\InvalidArgumentException;
 use Zend\Code\Generator\PropertyGenerator;
 use Zend\Code\Generator\PropertyValueGenerator;
-use Zend\Stdlib\ArrayObject as StdlibArrayObject;
 use Zend\Code\Generator\ValueGenerator;
+use Zend\Stdlib\ArrayObject as StdlibArrayObject;
 
 /**
  * @group Zend_Code_Generator
@@ -249,7 +249,7 @@ EOS;
     public function testPropertyDefaultValueConstructor()
     {
         $valueGenerator = new ValueGenerator();
-        $this->isInstanceOf($valueGenerator, 'Zend\Code\Generator\ValueGenerator');
+        $this->assertInstanceOf(ValueGenerator::class, $valueGenerator);
     }
 
     public function testPropertyDefaultValueIsSettable()

--- a/test/Generic/Prototype/PrototypeClassFactoryTest.php
+++ b/test/Generic/Prototype/PrototypeClassFactoryTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\Code\Generic\Prototype;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Code\Generic\Prototype\PrototypeClassFactory;
 use ZendTest\Code\Generator\TestAsset\PrototypeClass;
 use ZendTest\Code\Generator\TestAsset\PrototypeGenericClass;
@@ -17,7 +18,7 @@ use ZendTest\Code\Generator\TestAsset\PrototypeGenericClass;
  * @group Zend_Code_Generator
  * @group Zend_Code_Generator_Php
  */
-class PrototypeClassFactoryTest extends \PHPUnit_Framework_TestCase
+class PrototypeClassFactoryTest extends TestCase
 {
     /**
      * @var PrototypeClassFactory
@@ -52,7 +53,9 @@ class PrototypeClassFactoryTest extends \PHPUnit_Framework_TestCase
 
     public function testSetNameOnGenericIsCalledOnce()
     {
-        $mockProto = $this->getMock('ZendTest\Code\Generator\TestAsset\PrototypeGenericClass', ['setName']);
+        $mockProto = $this->getMockBuilder('ZendTest\Code\Generator\TestAsset\PrototypeGenericClass')
+            ->setMethods(['setName'])
+            ->getMock();
         $mockProto->expects($this->once())->method('setName')->will($this->returnValue('notexist'));
         $this->prototypeFactory->setGenericPrototype($mockProto);
         $this->prototypeFactory->getClonedPrototype('notexist');

--- a/test/Generic/Prototype/PrototypeClassFactoryTest.php
+++ b/test/Generic/Prototype/PrototypeClassFactoryTest.php
@@ -53,7 +53,7 @@ class PrototypeClassFactoryTest extends TestCase
 
     public function testSetNameOnGenericIsCalledOnce()
     {
-        $mockProto = $this->getMockBuilder('ZendTest\Code\Generator\TestAsset\PrototypeGenericClass')
+        $mockProto = $this->getMockBuilder(PrototypeGenericClass::class)
             ->setMethods(['setName'])
             ->getMock();
         $mockProto->expects($this->once())->method('setName')->will($this->returnValue('notexist'));

--- a/test/NameInformationTest.php
+++ b/test/NameInformationTest.php
@@ -9,9 +9,10 @@
 
 namespace ZendTest\Code;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Code\NameInformation;
 
-class NameInformationTest extends \PHPUnit_Framework_TestCase
+class NameInformationTest extends TestCase
 {
     public function testNamespaceResolverPersistsNamespace()
     {

--- a/test/Reflection/ClassReflectionTest.php
+++ b/test/Reflection/ClassReflectionTest.php
@@ -28,7 +28,7 @@ class ClassReflectionTest extends TestCase
         $this->assertEquals('Zend\Code\Reflection\MethodReflection', get_class($methodByName));
 
         $methodsAll = $reflectionClass->getMethods();
-        $this->assertEquals(3, count($methodsAll));
+        $this->assertCount(3, $methodsAll);
 
         $firstMethod = array_shift($methodsAll);
         $this->assertEquals('getProp1', $firstMethod->getName());
@@ -42,7 +42,7 @@ class ClassReflectionTest extends TestCase
         $this->assertInstanceOf('Zend\Code\Reflection\PropertyReflection', $propertyByName);
 
         $propertiesAll = $reflectionClass->getProperties();
-        $this->assertEquals(2, count($propertiesAll));
+        $this->assertCount(2, $propertiesAll);
 
         $firstProperty = array_shift($propertiesAll);
         $this->assertEquals('_prop1', $firstProperty->getName());
@@ -62,7 +62,7 @@ class ClassReflectionTest extends TestCase
         $reflectionClass = new ClassReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass4');
 
         $interfaces = $reflectionClass->getInterfaces();
-        $this->assertEquals(1, count($interfaces));
+        $this->assertCount(1, $interfaces);
 
         $interface = array_shift($interfaces);
         $this->assertEquals('ZendTest\Code\Reflection\TestAsset\TestSampleClassInterface', $interface->getName());

--- a/test/Reflection/ClassReflectionTest.php
+++ b/test/Reflection/ClassReflectionTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\Code\Reflection;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Code\Reflection\ClassReflection;
 use ZendTest\Code\Reflection\TestAsset\InjectableClassReflection;
 
@@ -17,7 +18,7 @@ use ZendTest\Code\Reflection\TestAsset\InjectableClassReflection;
  * @group      Zend_Reflection
  * @group      Zend_Reflection_Class
  */
-class ClassReflectionTest extends \PHPUnit_Framework_TestCase
+class ClassReflectionTest extends TestCase
 {
     public function testMethodReturns()
     {

--- a/test/Reflection/ClassReflectionTest.php
+++ b/test/Reflection/ClassReflectionTest.php
@@ -10,7 +10,11 @@
 namespace ZendTest\Code\Reflection;
 
 use PHPUnit\Framework\TestCase;
+use Zend\Code\Annotation\AnnotationManager;
 use Zend\Code\Reflection\ClassReflection;
+use Zend\Code\Reflection\MethodReflection;
+use Zend\Code\Reflection\PropertyReflection;
+use Zend\Code\Scanner\FileScanner;
 use ZendTest\Code\Reflection\TestAsset\InjectableClassReflection;
 
 /**
@@ -22,10 +26,10 @@ class ClassReflectionTest extends TestCase
 {
     public function testMethodReturns()
     {
-        $reflectionClass = new ClassReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass2');
+        $reflectionClass = new ClassReflection(TestAsset\TestSampleClass2::class);
 
         $methodByName = $reflectionClass->getMethod('getProp1');
-        $this->assertEquals('Zend\Code\Reflection\MethodReflection', get_class($methodByName));
+        $this->assertEquals(MethodReflection::class, get_class($methodByName));
 
         $methodsAll = $reflectionClass->getMethods();
         $this->assertCount(3, $methodsAll);
@@ -36,10 +40,10 @@ class ClassReflectionTest extends TestCase
 
     public function testPropertyReturns()
     {
-        $reflectionClass = new ClassReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass2');
+        $reflectionClass = new ClassReflection(TestAsset\TestSampleClass2::class);
 
         $propertyByName = $reflectionClass->getProperty('_prop1');
-        $this->assertInstanceOf('Zend\Code\Reflection\PropertyReflection', $propertyByName);
+        $this->assertInstanceOf(PropertyReflection::class, $propertyByName);
 
         $propertiesAll = $reflectionClass->getProperties();
         $this->assertCount(2, $propertiesAll);
@@ -50,27 +54,27 @@ class ClassReflectionTest extends TestCase
 
     public function testParentReturn()
     {
-        $reflectionClass = new ClassReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass');
+        $reflectionClass = new ClassReflection(TestAsset\TestSampleClass::class);
 
         $parent = $reflectionClass->getParentClass();
-        $this->assertEquals('Zend\Code\Reflection\ClassReflection', get_class($parent));
+        $this->assertEquals(ClassReflection::class, get_class($parent));
         $this->assertEquals('ArrayObject', $parent->getName());
     }
 
     public function testInterfaceReturn()
     {
-        $reflectionClass = new ClassReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass4');
+        $reflectionClass = new ClassReflection(TestAsset\TestSampleClass4::class);
 
         $interfaces = $reflectionClass->getInterfaces();
         $this->assertCount(1, $interfaces);
 
         $interface = array_shift($interfaces);
-        $this->assertEquals('ZendTest\Code\Reflection\TestAsset\TestSampleClassInterface', $interface->getName());
+        $this->assertEquals(TestAsset\TestSampleClassInterface::class, $interface->getName());
     }
 
     public function testGetContentsReturnsContents()
     {
-        $reflectionClass = new ClassReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass2');
+        $reflectionClass = new ClassReflection(TestAsset\TestSampleClass2::class);
         $target = <<<EOS
 {
     protected \$_prop1 = null;
@@ -103,7 +107,7 @@ EOS;
 
     public function testGetContentsReturnsContentsWithImplementsOnSeparateLine()
     {
-        $reflectionClass = new ClassReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass9');
+        $reflectionClass = new ClassReflection(TestAsset\TestSampleClass9::class);
         $target = <<<EOS
 {
     protected \$_prop1 = null;
@@ -136,7 +140,7 @@ EOS;
 
     public function testStartLine()
     {
-        $reflectionClass = new ClassReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass5');
+        $reflectionClass = new ClassReflection(TestAsset\TestSampleClass5::class);
 
         $this->assertEquals(18, $reflectionClass->getStartLine());
         $this->assertEquals(5, $reflectionClass->getStartLine(true));
@@ -144,7 +148,7 @@ EOS;
 
     public function testGetDeclaringFileReturnsFilename()
     {
-        $reflectionClass = new ClassReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass2');
+        $reflectionClass = new ClassReflection(TestAsset\TestSampleClass2::class);
         $this->assertContains('TestSampleClass2.php', $reflectionClass->getDeclaringFile()->getFileName());
     }
 
@@ -153,12 +157,12 @@ EOS;
         $reflectionClass = new InjectableClassReflection(
             // TestSampleClass5 has the annotations required to get to the
             // right point in the getAnnotations method.
-            'ZendTest\Code\Reflection\TestAsset\TestSampleClass5'
+            TestAsset\TestSampleClass5::class
         );
 
-        $annotationManager = new \Zend\Code\Annotation\AnnotationManager();
+        $annotationManager = new AnnotationManager();
 
-        $fileScanner = $this->getMockBuilder('Zend\Code\Scanner\FileScanner')
+        $fileScanner = $this->getMockBuilder(FileScanner::class)
                             ->disableOriginalConstructor()
                             ->getMock();
 
@@ -193,13 +197,13 @@ EOS;
         // PHP documentations mentions that getTraits() return NULL in case of error. I don't know how to cause such
         // error so I test just normal behaviour.
 
-        $reflectionClass = new ClassReflection('ZendTest\Code\Reflection\TestAsset\TestTraitClass4');
+        $reflectionClass = new ClassReflection(TestAsset\TestTraitClass4::class);
         $traitsArray = $reflectionClass->getTraits();
         $this->assertInternalType('array', $traitsArray);
         $this->assertCount(1, $traitsArray);
-        $this->assertInstanceOf('Zend\Code\Reflection\ClassReflection', $traitsArray[0]);
+        $this->assertInstanceOf(ClassReflection::class, $traitsArray[0]);
 
-        $reflectionClass = new ClassReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass');
+        $reflectionClass = new ClassReflection(TestAsset\TestSampleClass::class);
         $traitsArray = $reflectionClass->getTraits();
         $this->assertInternalType('array', $traitsArray);
         $this->assertCount(0, $traitsArray);

--- a/test/Reflection/DocBlock/Tag/AuthorTagTest.php
+++ b/test/Reflection/DocBlock/Tag/AuthorTagTest.php
@@ -9,13 +9,14 @@
 
 namespace ZendTest\Code\Reflection\DocBlock\Tag;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Code\Reflection\DocBlock\Tag\AuthorTag;
 
 /**
  * @group      Zend_Reflection
  * @group      Zend_Reflection_DocBlock
  */
-class AuthorTagTest extends \PHPUnit_Framework_TestCase
+class AuthorTagTest extends TestCase
 {
     /**
      * @var AuthorTag

--- a/test/Reflection/DocBlock/Tag/GenericTagTest.php
+++ b/test/Reflection/DocBlock/Tag/GenericTagTest.php
@@ -9,13 +9,14 @@
 
 namespace ZendTest\Code\Reflection\DocBlock\Tag;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Code\Reflection\DocBlock\Tag\GenericTag;
 
 /**
  * @group      Zend_Reflection
  * @group      Zend_Reflection_DocBlock
  */
-class GenericTagTest extends \PHPUnit_Framework_TestCase
+class GenericTagTest extends TestCase
 {
     /**
      * @group ZF2-146

--- a/test/Reflection/DocBlock/Tag/LicenseTagTest.php
+++ b/test/Reflection/DocBlock/Tag/LicenseTagTest.php
@@ -9,13 +9,14 @@
 
 namespace ZendTest\Code\Reflection\DocBlock\Tag;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Code\Reflection\DocBlock\Tag\LicenseTag;
 
 /**
  * @group      Zend_Reflection
  * @group      Zend_Reflection_DocBlock
  */
-class LicenseTagTest extends \PHPUnit_Framework_TestCase
+class LicenseTagTest extends TestCase
 {
     /**
      * @var LicenseTag

--- a/test/Reflection/DocBlock/Tag/MethodTagTest.php
+++ b/test/Reflection/DocBlock/Tag/MethodTagTest.php
@@ -9,13 +9,14 @@
 
 namespace ZendTest\Code\Reflection\DocBlock\Tag;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Code\Reflection\DocBlock\Tag\MethodTag;
 
 /**
  * @group      Zend_Reflection
  * @group      Zend_Reflection_DocBlock
  */
-class MethodTagTest extends \PHPUnit_Framework_TestCase
+class MethodTagTest extends TestCase
 {
     public function testParseName()
     {

--- a/test/Reflection/DocBlock/Tag/PropertyTagTest.php
+++ b/test/Reflection/DocBlock/Tag/PropertyTagTest.php
@@ -9,13 +9,14 @@
 
 namespace ZendTest\Code\Reflection\DocBlock\Tag;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Code\Reflection\DocBlock\Tag\PropertyTag;
 
 /**
  * @group      Zend_Reflection
  * @group      Zend_Reflection_DocBlock
  */
-class PropertyTagTest extends \PHPUnit_Framework_TestCase
+class PropertyTagTest extends TestCase
 {
     public function testParseName()
     {

--- a/test/Reflection/DocBlock/Tag/ThrowsTagTest.php
+++ b/test/Reflection/DocBlock/Tag/ThrowsTagTest.php
@@ -9,13 +9,14 @@
 
 namespace ZendTest\Code\Reflection\DocBlock\Tag;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Code\Reflection\DocBlock\Tag\ThrowsTag;
 
 /**
  * @group      Zend_Reflection
  * @group      Zend_Reflection_DocBlock
  */
-class ThrowsTagTest extends \PHPUnit_Framework_TestCase
+class ThrowsTagTest extends TestCase
 {
     public function testAllCharactersFromTypenameAreSupported()
     {

--- a/test/Reflection/DocBlockReflectionTest.php
+++ b/test/Reflection/DocBlockReflectionTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\Code\Reflection;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Code\Reflection\ClassReflection;
 use Zend\Code\Reflection\DocBlockReflection;
 
@@ -18,7 +19,7 @@ use Zend\Code\Reflection\DocBlockReflection;
  * @group      Zend_Reflection
  * @group      Zend_Reflection_DocBlock
  */
-class DocBlockReflectionTest extends \PHPUnit_Framework_TestCase
+class DocBlockReflectionTest extends TestCase
 {
     public function testDocBlockShortDescription()
     {

--- a/test/Reflection/DocBlockReflectionTest.php
+++ b/test/Reflection/DocBlockReflectionTest.php
@@ -44,10 +44,10 @@ class DocBlockReflectionTest extends TestCase
     {
         $classReflection = new ClassReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass5');
 
-        $this->assertEquals(3, count($classReflection->getDocBlock()->getTags()));
-        $this->assertEquals(1, count($classReflection->getDocBlock()->getTags('author')));
-        $this->assertEquals(1, count($classReflection->getDocBlock()->getTags('property')));
-        $this->assertEquals(1, count($classReflection->getDocBlock()->getTags('method')));
+        $this->assertCount(3, $classReflection->getDocBlock()->getTags());
+        $this->assertCount(1, $classReflection->getDocBlock()->getTags('author'));
+        $this->assertCount(1, $classReflection->getDocBlock()->getTags('property'));
+        $this->assertCount(1, $classReflection->getDocBlock()->getTags('method'));
 
         $methodTag = $classReflection->getDocBlock()->getTag('method');
         $this->assertInstanceOf('Zend\Code\Reflection\DocBlock\Tag\MethodTag', $methodTag);
@@ -85,10 +85,10 @@ class DocBlockReflectionTest extends TestCase
     {
         $classReflection = new ClassReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass10');
 
-        $this->assertEquals(3, count($classReflection->getDocBlock()->getTags()));
-        $this->assertEquals(1, count($classReflection->getDocBlock()->getTags('author')));
-        $this->assertEquals(1, count($classReflection->getDocBlock()->getTags('property')));
-        $this->assertEquals(1, count($classReflection->getDocBlock()->getTags('method')));
+        $this->assertCount(3, $classReflection->getDocBlock()->getTags());
+        $this->assertCount(1, $classReflection->getDocBlock()->getTags('author'));
+        $this->assertCount(1, $classReflection->getDocBlock()->getTags('property'));
+        $this->assertCount(1, $classReflection->getDocBlock()->getTags('method'));
 
         $methodTag = $classReflection->getDocBlock()->getTag('method');
         $this->assertInstanceOf('Zend\Code\Reflection\DocBlock\Tag\MethodTag', $methodTag);
@@ -176,10 +176,10 @@ EOS;
 
         $paramTags = $docblockReflection->getTags('param');
 
-        $this->assertEquals(5, count($docblockReflection->getTags()));
-        $this->assertEquals(3, count($paramTags));
-        $this->assertEquals(1, count($docblockReflection->getTags('return')));
-        $this->assertEquals(1, count($docblockReflection->getTags('throws')));
+        $this->assertCount(5, $docblockReflection->getTags());
+        $this->assertCount(3, $paramTags);
+        $this->assertCount(1, $docblockReflection->getTags('return'));
+        $this->assertCount(1, $docblockReflection->getTags('throws'));
 
         $returnTag = $docblockReflection->getTag('return');
         $this->assertInstanceOf('Zend\Code\Reflection\DocBlock\Tag\ReturnTag', $returnTag);

--- a/test/Reflection/DocBlockReflectionTest.php
+++ b/test/Reflection/DocBlockReflectionTest.php
@@ -11,6 +11,12 @@ namespace ZendTest\Code\Reflection;
 
 use PHPUnit\Framework\TestCase;
 use Zend\Code\Reflection\ClassReflection;
+use Zend\Code\Reflection\DocBlock\Tag\MethodTag;
+use Zend\Code\Reflection\DocBlock\Tag\ParamTag;
+use Zend\Code\Reflection\DocBlock\Tag\PropertyTag;
+use Zend\Code\Reflection\DocBlock\Tag\ReturnTag;
+use Zend\Code\Reflection\DocBlock\Tag\TagInterface;
+use Zend\Code\Reflection\DocBlock\Tag\ThrowsTag;
 use Zend\Code\Reflection\DocBlockReflection;
 
 /**
@@ -23,7 +29,7 @@ class DocBlockReflectionTest extends TestCase
 {
     public function testDocBlockShortDescription()
     {
-        $classReflection = new ClassReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass5');
+        $classReflection = new ClassReflection(TestAsset\TestSampleClass5::class);
         $this->assertEquals(
             'TestSampleClass5 DocBlock Short Desc',
             $classReflection->getDocBlock()->getShortDescription()
@@ -32,7 +38,7 @@ class DocBlockReflectionTest extends TestCase
 
     public function testDocBlockLongDescription()
     {
-        $classReflection = new ClassReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass5');
+        $classReflection = new ClassReflection(TestAsset\TestSampleClass5::class);
         $expectedOutput = 'This is a long description for the docblock of this class, it should be longer '
             . 'than 3 lines. It indeed is longer than 3 lines now.';
 
@@ -42,7 +48,7 @@ class DocBlockReflectionTest extends TestCase
 
     public function testDocBlockTags()
     {
-        $classReflection = new ClassReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass5');
+        $classReflection = new ClassReflection(TestAsset\TestSampleClass5::class);
 
         $this->assertCount(3, $classReflection->getDocBlock()->getTags());
         $this->assertCount(1, $classReflection->getDocBlock()->getTags('author'));
@@ -50,24 +56,24 @@ class DocBlockReflectionTest extends TestCase
         $this->assertCount(1, $classReflection->getDocBlock()->getTags('method'));
 
         $methodTag = $classReflection->getDocBlock()->getTag('method');
-        $this->assertInstanceOf('Zend\Code\Reflection\DocBlock\Tag\MethodTag', $methodTag);
+        $this->assertInstanceOf(MethodTag::class, $methodTag);
 
         $propertyTag = $classReflection->getDocBlock()->getTag('property');
-        $this->assertInstanceOf('Zend\Code\Reflection\DocBlock\Tag\PropertyTag', $propertyTag);
+        $this->assertInstanceOf(PropertyTag::class, $propertyTag);
 
         $this->assertFalse($classReflection->getDocBlock()->getTag('version'));
 
         $this->assertTrue($classReflection->getMethod('doSomething')->getDocBlock()->hasTag('return'));
 
         $returnTag = $classReflection->getMethod('doSomething')->getDocBlock()->getTag('return');
-        $this->assertInstanceOf('Zend\Code\Reflection\DocBlock\Tag\TagInterface', $returnTag);
+        $this->assertInstanceOf(TagInterface::class, $returnTag);
         $this->assertEquals('mixed', $returnTag->getType());
     }
 
     public function testShortDocBlocks()
     {
-        $classReflection = new ClassReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass13');
-        $this->assertEquals(0, count($classReflection->getDocBlock()->getTags()));
+        $classReflection = new ClassReflection(TestAsset\TestSampleClass13::class);
+        $this->assertCount(0, $classReflection->getDocBlock()->getTags());
 
         $this->assertSame(
             'Short Method Description',
@@ -76,14 +82,14 @@ class DocBlockReflectionTest extends TestCase
         $this->assertSame('Short Class Description', $classReflection->getDocBlock()->getShortDescription());
 
         $returnTag = $classReflection->getMethod('returnSomething')->getDocBlock()->getTag('return');
-        $this->assertInstanceOf('Zend\Code\Reflection\DocBlock\Tag\TagInterface', $returnTag);
+        $this->assertInstanceOf(TagInterface::class, $returnTag);
         $this->assertEquals('Something', $returnTag->getType());
         $this->assertEquals('This describes something', $returnTag->getDescription());
     }
 
     public function testTabbedDocBlockTags()
     {
-        $classReflection = new ClassReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass10');
+        $classReflection = new ClassReflection(TestAsset\TestSampleClass10::class);
 
         $this->assertCount(3, $classReflection->getDocBlock()->getTags());
         $this->assertCount(1, $classReflection->getDocBlock()->getTags('author'));
@@ -91,23 +97,23 @@ class DocBlockReflectionTest extends TestCase
         $this->assertCount(1, $classReflection->getDocBlock()->getTags('method'));
 
         $methodTag = $classReflection->getDocBlock()->getTag('method');
-        $this->assertInstanceOf('Zend\Code\Reflection\DocBlock\Tag\MethodTag', $methodTag);
+        $this->assertInstanceOf(MethodTag::class, $methodTag);
 
         $propertyTag = $classReflection->getDocBlock()->getTag('property');
-        $this->assertInstanceOf('Zend\Code\Reflection\DocBlock\Tag\PropertyTag', $propertyTag);
+        $this->assertInstanceOf(PropertyTag::class, $propertyTag);
 
         $this->assertFalse($classReflection->getDocBlock()->getTag('version'));
 
         $this->assertTrue($classReflection->getMethod('doSomething')->getDocBlock()->hasTag('return'));
 
         $returnTag = $classReflection->getMethod('doSomething')->getDocBlock()->getTag('return');
-        $this->assertInstanceOf('Zend\Code\Reflection\DocBlock\Tag\TagInterface', $returnTag);
+        $this->assertInstanceOf(TagInterface::class, $returnTag);
         $this->assertEquals('mixed', $returnTag->getType());
     }
 
     public function testDocBlockLines()
     {
-        $classReflection = new ClassReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass5');
+        $classReflection = new ClassReflection(TestAsset\TestSampleClass5::class);
 
         $classDocBlock = $classReflection->getDocBlock();
 
@@ -117,7 +123,7 @@ class DocBlockReflectionTest extends TestCase
 
     public function testDocBlockContents()
     {
-        $classReflection = new ClassReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass5');
+        $classReflection = new ClassReflection(TestAsset\TestSampleClass5::class);
 
         $classDocBlock = $classReflection->getDocBlock();
 
@@ -141,7 +147,7 @@ EOS;
 
     public function testToString()
     {
-        $classReflection = new ClassReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass5');
+        $classReflection = new ClassReflection(TestAsset\TestSampleClass5::class);
 
         $classDocBlock = $classReflection->getDocBlock();
 
@@ -182,25 +188,25 @@ EOS;
         $this->assertCount(1, $docblockReflection->getTags('throws'));
 
         $returnTag = $docblockReflection->getTag('return');
-        $this->assertInstanceOf('Zend\Code\Reflection\DocBlock\Tag\ReturnTag', $returnTag);
+        $this->assertInstanceOf(ReturnTag::class, $returnTag);
         $this->assertEquals('int[]', $returnTag->getType());
         $this->assertEquals(['int[]', 'null'], $returnTag->getTypes());
         $this->assertEquals('Description', $returnTag->getDescription());
 
         $throwsTag = $docblockReflection->getTag('throws');
-        $this->assertInstanceOf('Zend\Code\Reflection\DocBlock\Tag\ThrowsTag', $throwsTag);
+        $this->assertInstanceOf(ThrowsTag::class, $throwsTag);
         $this->assertEquals('Exception', $throwsTag->getType());
 
         $paramTag = $paramTags[0];
-        $this->assertInstanceOf('Zend\Code\Reflection\DocBlock\Tag\ParamTag', $paramTag);
+        $this->assertInstanceOf(ParamTag::class, $paramTag);
         $this->assertEquals('int', $paramTag->getType());
 
         $paramTag = $paramTags[1];
-        $this->assertInstanceOf('Zend\Code\Reflection\DocBlock\Tag\ParamTag', $paramTag);
+        $this->assertInstanceOf(ParamTag::class, $paramTag);
         $this->assertEquals('int[]', $paramTag->getType());
 
         $paramTag = $paramTags[2];
-        $this->assertInstanceOf('Zend\Code\Reflection\DocBlock\Tag\ParamTag', $paramTag);
+        $this->assertInstanceOf(ParamTag::class, $paramTag);
         $this->assertEquals('string', $paramTag->getType());
         $this->assertEquals(['string', 'null'], $paramTag->getTypes());
     }

--- a/test/Reflection/FileReflectionTest.php
+++ b/test/Reflection/FileReflectionTest.php
@@ -79,7 +79,7 @@ class FileReflectionTest extends TestCase
         include_once $fileToReflect;
         $reflectionFile = new FileReflection($fileToReflect);
         $this->assertEquals(get_class($reflectionFile), 'Zend\Code\Reflection\FileReflection');
-        $this->assertEquals(count($reflectionFile->getClasses()), 1);
+        $this->assertCount(1, $reflectionFile->getClasses());
     }
 
     public function testFileGetClassReturnsFirstClassWithNoOptions()

--- a/test/Reflection/FileReflectionTest.php
+++ b/test/Reflection/FileReflectionTest.php
@@ -10,24 +10,27 @@
 namespace ZendTest\Code\Reflection;
 
 use Exception;
+use PHPUnit\Framework\TestCase;
 use Zend\Code\Reflection\FileReflection;
+use Zend\Code\Reflection\Exception\InvalidArgumentException;
+use Zend\Code\Reflection\Exception\RuntimeException;
 
 /**
  * @group      Zend_Reflection
  * @group      Zend_Reflection_File
  */
-class FileReflectionTest extends \PHPUnit_Framework_TestCase
+class FileReflectionTest extends TestCase
 {
     public function testFileConstructorThrowsExceptionOnNonExistentFile()
     {
         $nonExistentFile = 'Non/Existent/File.php';
-        $this->setExpectedException('Zend\Code\Reflection\Exception\InvalidArgumentException', 'found');
+        $this->expectException(InvalidArgumentException::class, 'found');
         $reflectionFile = new FileReflection($nonExistentFile);
     }
 
     public function testFileConstructorFromAReflectedFilenameInIncludePathWithoutIncludeFlagEnabled()
     {
-        $this->setExpectedException('Zend\Code\Reflection\Exception\RuntimeException', 'must be required');
+        $this->expectException(RuntimeException::class, 'must be required');
         $oldIncludePath = set_include_path(get_include_path() . PATH_SEPARATOR . __DIR__ . '/TestAsset/');
 
         try {
@@ -95,10 +98,8 @@ class FileReflectionTest extends \PHPUnit_Framework_TestCase
         $reflectionFile = new FileReflection($fileToReflect);
         $nonExistentClass = 'Some_Non_Existent_Class';
 
-        $this->setExpectedException(
-            'Zend\Code\Reflection\Exception\InvalidArgumentException',
-            'Class by name Some_Non_Existent_Class not found'
-        );
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Class by name Some_Non_Existent_Class not found');
         $reflectionFile->getClass($nonExistentClass);
     }
 

--- a/test/Reflection/FileReflectionTest.php
+++ b/test/Reflection/FileReflectionTest.php
@@ -11,9 +11,11 @@ namespace ZendTest\Code\Reflection;
 
 use Exception;
 use PHPUnit\Framework\TestCase;
-use Zend\Code\Reflection\FileReflection;
+use Zend\Code\Reflection\DocBlockReflection;
 use Zend\Code\Reflection\Exception\InvalidArgumentException;
 use Zend\Code\Reflection\Exception\RuntimeException;
+use Zend\Code\Reflection\FileReflection;
+use Zend\Code\Reflection\FunctionReflection;
 
 /**
  * @group      Zend_Reflection
@@ -26,7 +28,7 @@ class FileReflectionTest extends TestCase
         $nonExistentFile = 'Non/Existent/File.php';
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('found');
-        $reflectionFile = new FileReflection($nonExistentFile);
+        new FileReflection($nonExistentFile);
     }
 
     public function testFileConstructorFromAReflectedFilenameInIncludePathWithoutIncludeFlagEnabled()
@@ -78,7 +80,7 @@ class FileReflectionTest extends TestCase
         $fileToReflect = __DIR__ . '/TestAsset/TestSampleClass.php';
         include_once $fileToReflect;
         $reflectionFile = new FileReflection($fileToReflect);
-        $this->assertEquals(get_class($reflectionFile), 'Zend\Code\Reflection\FileReflection');
+        $this->assertEquals(get_class($reflectionFile), FileReflection::class);
         $this->assertCount(1, $reflectionFile->getClasses());
     }
 
@@ -87,10 +89,7 @@ class FileReflectionTest extends TestCase
         $fileToReflect = __DIR__ . '/TestAsset/TestSampleClass.php';
         include_once $fileToReflect;
         $reflectionFile = new FileReflection($fileToReflect);
-        $this->assertEquals(
-            'ZendTest\Code\Reflection\TestAsset\TestSampleClass',
-            $reflectionFile->getClass()->getName()
-        );
+        $this->assertEquals(TestAsset\TestSampleClass::class, $reflectionFile->getClass()->getName());
     }
 
     public function testFileGetClassThrowsExceptionOnNonExistentClassName()
@@ -138,7 +137,7 @@ class FileReflectionTest extends TestCase
         $reflectionFile = new FileReflection($fileToReflect);
 
         $reflectionDocBlock = $reflectionFile->getDocBlock();
-        $this->assertInstanceOf('Zend\Code\Reflection\DocBlockReflection', $reflectionDocBlock);
+        $this->assertInstanceOf(DocBlockReflection::class, $reflectionDocBlock);
 
         $authorTag = $reflectionDocBlock->getTag('author');
         $this->assertEquals('Jeremiah Small', $authorTag->getAuthorName());
@@ -153,7 +152,7 @@ class FileReflectionTest extends TestCase
         include_once $fileToRequire;
         $reflectionFile = new FileReflection($fileToRequire);
         $funcs = $reflectionFile->getFunctions();
-        $this->assertInstanceOf('Zend\Code\Reflection\FunctionReflection', current($funcs));
+        $this->assertInstanceOf(FunctionReflection::class, current($funcs));
     }
 
     public function testFileCanReflectFileWithInterface()
@@ -162,7 +161,7 @@ class FileReflectionTest extends TestCase
         include_once $fileToReflect;
         $reflectionFile = new FileReflection($fileToReflect);
         $class = $reflectionFile->getClass();
-        $this->assertEquals('ZendTest\Code\Reflection\TestAsset\TestSampleInterface', $class->getName());
+        $this->assertEquals(TestAsset\TestSampleInterface::class, $class->getName());
         $this->assertTrue($class->isInterface());
     }
 
@@ -174,8 +173,8 @@ class FileReflectionTest extends TestCase
         $expected = [
             ['use' => 'Zend\Config', 'as' => 'ZendConfig'],
             ['use' => 'FooBar\Foo\Bar', 'as' => null],
-            ['use' => 'One\Two\Three\Four\Five', 'as' => 'ottff']
-            ];
+            ['use' => 'One\Two\Three\Four\Five', 'as' => 'ottff'],
+        ];
         $this->assertSame($expected, $reflectionFile->getUses());
     }
 

--- a/test/Reflection/FileReflectionTest.php
+++ b/test/Reflection/FileReflectionTest.php
@@ -24,13 +24,15 @@ class FileReflectionTest extends TestCase
     public function testFileConstructorThrowsExceptionOnNonExistentFile()
     {
         $nonExistentFile = 'Non/Existent/File.php';
-        $this->expectException(InvalidArgumentException::class, 'found');
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('found');
         $reflectionFile = new FileReflection($nonExistentFile);
     }
 
     public function testFileConstructorFromAReflectedFilenameInIncludePathWithoutIncludeFlagEnabled()
     {
-        $this->expectException(RuntimeException::class, 'must be required');
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('must be required');
         $oldIncludePath = set_include_path(get_include_path() . PATH_SEPARATOR . __DIR__ . '/TestAsset/');
 
         try {

--- a/test/Reflection/FunctionReflectionTest.php
+++ b/test/Reflection/FunctionReflectionTest.php
@@ -23,7 +23,7 @@ class FunctionReflectionTest extends TestCase
     {
         $function = new FunctionReflection('array_splice');
         $parameters = $function->getParameters();
-        $this->assertEquals(count($parameters), 4);
+        $this->assertCount(4, $parameters);
         $this->assertInstanceOf('Zend\Code\Reflection\ParameterReflection', array_shift($parameters));
     }
 

--- a/test/Reflection/FunctionReflectionTest.php
+++ b/test/Reflection/FunctionReflectionTest.php
@@ -10,8 +10,10 @@
 namespace ZendTest\Code\Reflection;
 
 use PHPUnit\Framework\TestCase;
-use Zend\Code\Reflection\FunctionReflection;
+use Zend\Code\Reflection\DocBlockReflection;
 use Zend\Code\Reflection\Exception\InvalidArgumentException;
+use Zend\Code\Reflection\FunctionReflection;
+use Zend\Code\Reflection\ParameterReflection;
 
 /**
  * @group      Zend_Reflection
@@ -24,14 +26,14 @@ class FunctionReflectionTest extends TestCase
         $function = new FunctionReflection('array_splice');
         $parameters = $function->getParameters();
         $this->assertCount(4, $parameters);
-        $this->assertInstanceOf('Zend\Code\Reflection\ParameterReflection', array_shift($parameters));
+        $this->assertInstanceOf(ParameterReflection::class, array_shift($parameters));
     }
 
     public function testFunctionDocBlockReturn()
     {
         require_once __DIR__ . '/TestAsset/functions.php';
         $function = new FunctionReflection('ZendTest\Code\Reflection\TestAsset\function3');
-        $this->assertInstanceOf('Zend\Code\Reflection\DocBlockReflection', $function->getDocBlock());
+        $this->assertInstanceOf(DocBlockReflection::class, $function->getDocBlock());
     }
 
     public function testGetPrototypeMethod()
@@ -69,7 +71,7 @@ class FunctionReflectionTest extends TestCase
     {
         $function = new FunctionReflection('array_splice');
         $this->expectException(InvalidArgumentException::class);
-        $body = $function->getBody();
+        $function->getBody();
     }
 
     public function testFunctionBodyReturn()
@@ -220,7 +222,7 @@ class FunctionReflectionTest extends TestCase
 
         $function = new FunctionReflection('ZendTest\Code\Reflection\TestAsset\function12');
         $content = $function->getContents(false);
-        $this->assertEquals("function function12() {}", trim($content));
+        $this->assertEquals('function function12() {}', trim($content));
     }
 
     /**
@@ -236,7 +238,7 @@ class FunctionReflectionTest extends TestCase
 
         $function = new FunctionReflection($function9);
         $content = $function->getContents(false);
-        $this->assertEquals("function() {}", trim($content));
+        $this->assertEquals('function() {}', trim($content));
 
         $function = new FunctionReflection($function10);
         $content = $function->getContents(false);

--- a/test/Reflection/FunctionReflectionTest.php
+++ b/test/Reflection/FunctionReflectionTest.php
@@ -9,13 +9,15 @@
 
 namespace ZendTest\Code\Reflection;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Code\Reflection\FunctionReflection;
+use Zend\Code\Reflection\Exception\InvalidArgumentException;
 
 /**
  * @group      Zend_Reflection
  * @group      Zend_Reflection_Function
  */
-class FunctionReflectionTest extends \PHPUnit_Framework_TestCase
+class FunctionReflectionTest extends TestCase
 {
     public function testParemeterReturn()
     {
@@ -66,7 +68,7 @@ class FunctionReflectionTest extends \PHPUnit_Framework_TestCase
     public function testInternalFunctionBodyReturn()
     {
         $function = new FunctionReflection('array_splice');
-        $this->setExpectedException('Zend\Code\Reflection\Exception\InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
         $body = $function->getBody();
     }
 

--- a/test/Reflection/MethodReflectionTest.php
+++ b/test/Reflection/MethodReflectionTest.php
@@ -29,7 +29,7 @@ class MethodReflectionTest extends TestCase
     {
         $method = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass2', 'getProp2');
         $parameters = $method->getParameters();
-        $this->assertEquals(2, count($parameters));
+        $this->assertCount(2, $parameters);
         $this->assertInstanceOf('Zend\Code\Reflection\ParameterReflection', array_shift($parameters));
     }
 

--- a/test/Reflection/MethodReflectionTest.php
+++ b/test/Reflection/MethodReflectionTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\Code\Reflection;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Code\Reflection\MethodReflection;
 use ZendTest\Code\Reflection\TestAsset\InjectableMethodReflection;
 
@@ -16,7 +17,7 @@ use ZendTest\Code\Reflection\TestAsset\InjectableMethodReflection;
  * @group      Zend_Reflection
  * @group      Zend_Reflection_Method
  */
-class MethodReflectionTest extends \PHPUnit_Framework_TestCase
+class MethodReflectionTest extends TestCase
 {
     public function testDeclaringClassReturn()
     {
@@ -386,7 +387,7 @@ CONTENTS;
      */
     public function testCodeGetBodyReturnsEmptyWithCommentedFunction()
     {
-        $this->setExpectedException('ReflectionException');
+        $this->expectException('ReflectionException');
         $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass11', '__prototype');
         $reflectionMethod->getBody();
     }

--- a/test/Reflection/MethodReflectionTest.php
+++ b/test/Reflection/MethodReflectionTest.php
@@ -10,7 +10,11 @@
 namespace ZendTest\Code\Reflection;
 
 use PHPUnit\Framework\TestCase;
+use Zend\Code\Annotation\AnnotationManager;
+use Zend\Code\Reflection\ClassReflection;
 use Zend\Code\Reflection\MethodReflection;
+use Zend\Code\Reflection\ParameterReflection;
+use Zend\Code\Scanner\CachingFileScanner;
 use ZendTest\Code\Reflection\TestAsset\InjectableMethodReflection;
 
 /**
@@ -21,21 +25,21 @@ class MethodReflectionTest extends TestCase
 {
     public function testDeclaringClassReturn()
     {
-        $method = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass2', 'getProp1');
-        $this->assertInstanceOf('Zend\Code\Reflection\ClassReflection', $method->getDeclaringClass());
+        $method = new MethodReflection(TestAsset\TestSampleClass2::class, 'getProp1');
+        $this->assertInstanceOf(ClassReflection::class, $method->getDeclaringClass());
     }
 
     public function testParemeterReturn()
     {
-        $method = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass2', 'getProp2');
+        $method = new MethodReflection(TestAsset\TestSampleClass2::class, 'getProp2');
         $parameters = $method->getParameters();
         $this->assertCount(2, $parameters);
-        $this->assertInstanceOf('Zend\Code\Reflection\ParameterReflection', array_shift($parameters));
+        $this->assertInstanceOf(ParameterReflection::class, array_shift($parameters));
     }
 
     public function testStartLine()
     {
-        $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass5', 'doSomething');
+        $reflectionMethod = new MethodReflection(TestAsset\TestSampleClass5::class, 'doSomething');
 
         $this->assertEquals(37, $reflectionMethod->getStartLine());
         $this->assertEquals(21, $reflectionMethod->getStartLine(true));
@@ -55,57 +59,45 @@ class MethodReflectionTest extends TestCase
         $alsoAssigined = 2;
         return \'mixedValue\';';
 
-        $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass6', 'doSomething');
+        $reflectionMethod = new MethodReflection(TestAsset\TestSampleClass6::class, 'doSomething');
         $this->assertEquals($body, $reflectionMethod->getBody());
 
-        $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass11', 'doSomething');
+        $reflectionMethod = new MethodReflection(TestAsset\TestSampleClass11::class, 'doSomething');
         $body = $reflectionMethod->getBody();
         $this->assertEquals(trim($body), "return 'doSomething';");
 
-        $reflectionMethod = new MethodReflection(
-            'ZendTest\Code\Reflection\TestAsset\TestSampleClass11',
-            'doSomethingElse'
-        );
+        $reflectionMethod = new MethodReflection(TestAsset\TestSampleClass11::class, 'doSomethingElse');
         $body = $reflectionMethod->getBody();
         $this->assertEquals(trim($body), "return 'doSomethingElse';");
 
-        $reflectionMethod = new MethodReflection(
-            'ZendTest\Code\Reflection\TestAsset\TestSampleClass11',
-            'doSomethingAgain'
-        );
+        $reflectionMethod = new MethodReflection(TestAsset\TestSampleClass11::class, 'doSomethingAgain');
         $body = $reflectionMethod->getBody();
         $this->assertEquals(
             trim($body),
             "\$closure = function(\$foo) { return \$foo; };\n\n        return 'doSomethingAgain';"
         );
 
-        $reflectionMethod = new MethodReflection(
-            'ZendTest\Code\Reflection\TestAsset\TestSampleClass11',
-            'doStaticSomething'
-        );
+        $reflectionMethod = new MethodReflection(TestAsset\TestSampleClass11::class, 'doStaticSomething');
         $body = $reflectionMethod->getBody();
         $this->assertEquals(trim($body), "return 'doStaticSomething';");
 
-        $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass11', 'inline1');
+        $reflectionMethod = new MethodReflection(TestAsset\TestSampleClass11::class, 'inline1');
         $body = $reflectionMethod->getBody();
         $this->assertEquals(trim($body), "return 'inline1';");
 
-        $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass11', 'inline2');
+        $reflectionMethod = new MethodReflection(TestAsset\TestSampleClass11::class, 'inline2');
         $body = $reflectionMethod->getBody();
         $this->assertEquals(trim($body), "return 'inline2';");
 
-        $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass11', 'inline3');
+        $reflectionMethod = new MethodReflection(TestAsset\TestSampleClass11::class, 'inline3');
         $body = $reflectionMethod->getBody();
         $this->assertEquals(trim($body), "return 'inline3';");
 
-        $reflectionMethod = new MethodReflection(
-            'ZendTest\Code\Reflection\TestAsset\TestSampleClass11',
-            'emptyFunction'
-        );
+        $reflectionMethod = new MethodReflection(TestAsset\TestSampleClass11::class, 'emptyFunction');
         $body = $reflectionMethod->getBody();
-        $this->assertEquals(trim($body), "");
+        $this->assertEquals(trim($body), '');
 
-        $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass11', 'visibility');
+        $reflectionMethod = new MethodReflection(TestAsset\TestSampleClass11::class, 'visibility');
         $body = $reflectionMethod->getBody();
         $this->assertEquals(trim($body), "return 'visibility';");
     }
@@ -127,13 +119,13 @@ class MethodReflectionTest extends TestCase
         return 'doSomething';
     }
 CONTENTS;
-        $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass11', 'doSomething');
+        $reflectionMethod = new MethodReflection(TestAsset\TestSampleClass11::class, 'doSomething');
         $this->assertEquals($contents, $reflectionMethod->getContents(false));
 
         $contents = '    public function doSomethingElse($one, $two = 2, $three = \'three\')'
             . ' { return \'doSomethingElse\'; }';
         $reflectionMethod = new MethodReflection(
-            'ZendTest\Code\Reflection\TestAsset\TestSampleClass11',
+            TestAsset\TestSampleClass11::class,
             'doSomethingElse'
         );
         $this->assertEquals($contents, $reflectionMethod->getContents(false));
@@ -147,21 +139,21 @@ CONTENTS;
     }
 CONTENTS;
         $reflectionMethod = new MethodReflection(
-            'ZendTest\Code\Reflection\TestAsset\TestSampleClass11',
+            TestAsset\TestSampleClass11::class,
             'doSomethingAgain'
         );
         $this->assertEquals($contents, $reflectionMethod->getContents(false));
 
         $contents = '    public function inline1() { return \'inline1\'; }';
-        $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass11', 'inline1');
+        $reflectionMethod = new MethodReflection(TestAsset\TestSampleClass11::class, 'inline1');
         $this->assertEquals($contents, $reflectionMethod->getContents(false));
 
         $contents = ' public function inline2() { return \'inline2\'; }';
-        $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass11', 'inline2');
+        $reflectionMethod = new MethodReflection(TestAsset\TestSampleClass11::class, 'inline2');
         $this->assertEquals($contents, $reflectionMethod->getContents(false));
 
         $contents = ' public function inline3() { return \'inline3\'; }';
-        $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass11', 'inline3');
+        $reflectionMethod = new MethodReflection(TestAsset\TestSampleClass11::class, 'inline3');
         $this->assertEquals($contents, $reflectionMethod->getContents(false));
 
         $contents = <<<'CONTENTS'
@@ -170,7 +162,7 @@ CONTENTS;
         return 'visibility';
     }
 CONTENTS;
-        $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass11', 'visibility');
+        $reflectionMethod = new MethodReflection(TestAsset\TestSampleClass11::class, 'visibility');
         $this->assertEquals($contents, $reflectionMethod->getContents(false));
     }
 
@@ -186,7 +178,7 @@ CONTENTS;
         return 'doSomething';
     }
 CONTENTS;
-        $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass11', 'doSomething');
+        $reflectionMethod = new MethodReflection(TestAsset\TestSampleClass11::class, 'doSomething');
         $this->assertEquals($contents, $reflectionMethod->getContents(true));
         $this->assertEquals($contents, $reflectionMethod->getContents());
 
@@ -197,7 +189,7 @@ CONTENTS;
     public function emptyFunction() {}
 CONTENTS;
         $reflectionMethod = new MethodReflection(
-            'ZendTest\Code\Reflection\TestAsset\TestSampleClass11',
+            TestAsset\TestSampleClass11::class,
             'emptyFunction'
         );
         $this->assertEquals($contents, $reflectionMethod->getContents(true));
@@ -206,7 +198,7 @@ CONTENTS;
     public function testGetPrototypeMethod()
     {
         $reflectionMethod = new MethodReflection(
-            'ZendTest\Code\Reflection\TestAsset\TestSampleClass10',
+            TestAsset\TestSampleClass10::class,
             'doSomethingElse'
         );
         $prototype = [
@@ -242,7 +234,7 @@ CONTENTS;
             $reflectionMethod->getPrototype(MethodReflection::PROTOTYPE_AS_STRING)
         );
 
-        $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass2', 'getProp2');
+        $reflectionMethod = new MethodReflection(TestAsset\TestSampleClass2::class, 'getProp2');
         $prototype = [
             'namespace' => 'ZendTest\Code\Reflection\TestAsset',
             'class' => 'TestSampleClass2',
@@ -257,7 +249,7 @@ CONTENTS;
                     'default'  => null,
                 ],
                 'param2' => [
-                    'type'     => 'ZendTest\Code\Reflection\TestAsset\TestSampleClass',
+                    'type'     => TestAsset\TestSampleClass::class,
                     'required' => true,
                     'by_ref'   => false,
                     'default'  => null,
@@ -270,7 +262,7 @@ CONTENTS;
             $reflectionMethod->getPrototype(MethodReflection::PROTOTYPE_AS_STRING)
         );
 
-        $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass12', 'doSomething');
+        $reflectionMethod = new MethodReflection(TestAsset\TestSampleClass12::class, 'doSomething');
         $prototype = [
             'namespace' => 'ZendTest\Code\Reflection\TestAsset',
             'class' => 'TestSampleClass12',
@@ -304,13 +296,13 @@ CONTENTS;
         $reflectionMethod = new InjectableMethodReflection(
             // TestSampleClass5 has the annotations required to get to the
             // right point in the getAnnotations method.
-            'ZendTest\Code\Reflection\TestAsset\TestSampleClass5',
+            TestAsset\TestSampleClass5::class,
             'doSomething'
         );
 
-        $annotationManager = new \Zend\Code\Annotation\AnnotationManager();
+        $annotationManager = new AnnotationManager();
 
-        $fileScanner = $this->getMockBuilder('Zend\Code\Scanner\CachingFileScanner')
+        $fileScanner = $this->getMockBuilder(CachingFileScanner::class)
                             ->disableOriginalConstructor()
                             ->getMock();
 
@@ -329,7 +321,7 @@ CONTENTS;
     public function testGetContentsWithCoreClass()
     {
         $reflectionMethod = new MethodReflection('DateTime', 'format');
-        $this->assertEquals("", $reflectionMethod->getContents(false));
+        $this->assertEquals('', $reflectionMethod->getContents(false));
     }
 
     public function testGetContentsReturnsEmptyContentsOnEvaldCode()
@@ -365,11 +357,11 @@ CONTENTS;
         foreach($args as $arg) {
             if (is_array($arg)) {
                 foreach ($arg as $argElement) {
-                    $cacheKey = hash("sha256", $cacheKey.$argElement);
+                    $cacheKey = hash('sha256', $cacheKey.$argElement);
                 }
             }
             else {
-                $cacheKey = hash("sha256", $cacheKey.$arg);
+                $cacheKey = hash('sha256', $cacheKey.$arg);
             }
             //blah
         }
@@ -378,7 +370,7 @@ CONTENTS;
     }
 CONTENTS;
 
-        $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass11', 'getCacheKey');
+        $reflectionMethod = new MethodReflection(TestAsset\TestSampleClass11::class, 'getCacheKey');
         $this->assertEquals($contents, $reflectionMethod->getContents(false));
     }
 
@@ -388,7 +380,7 @@ CONTENTS;
     public function testCodeGetBodyReturnsEmptyWithCommentedFunction()
     {
         $this->expectException('ReflectionException');
-        $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass11', '__prototype');
+        $reflectionMethod = new MethodReflection(TestAsset\TestSampleClass11::class, '__prototype');
         $reflectionMethod->getBody();
     }
 
@@ -401,7 +393,7 @@ CONTENTS;
         require_once __DIR__. '/TestAsset/TestTraitClass2.php';
         // $method = new \Zend\Code\Reflection\ClassReflection('\FooClass');
         // $traits = current($method->getTraits());
-        $method = new \Zend\Code\Reflection\MethodReflection('FooClass', 'getDummy');
+        $method = new MethodReflection('FooClass', 'getDummy');
         $this->assertEquals(trim($method->getBody()), 'return $this->dummy;');
     }
 }

--- a/test/Reflection/ParameterReflectionTest.php
+++ b/test/Reflection/ParameterReflectionTest.php
@@ -11,6 +11,7 @@ namespace ZendTest\Code\Reflection;
 
 use PHPUnit\Framework\TestCase;
 use Zend\Code\Reflection;
+use Zend\Code\Reflection\ClassReflection;
 use ZendTest\Code\TestAsset\ClassTypeHintedClass;
 use ZendTest\Code\TestAsset\DocBlockOnlyHintsClass;
 use ZendTest\Code\TestAsset\InternalHintsClass;
@@ -24,16 +25,16 @@ class ParameterReflectionTest extends TestCase
     public function testDeclaringClassReturn()
     {
         $parameter = new Reflection\ParameterReflection(
-            ['ZendTest\Code\Reflection\TestAsset\TestSampleClass2', 'getProp2'],
+            [TestAsset\TestSampleClass2::class, 'getProp2'],
             0
         );
-        $this->assertInstanceOf('Zend\Code\Reflection\ClassReflection', $parameter->getDeclaringClass());
+        $this->assertInstanceOf(ClassReflection::class, $parameter->getDeclaringClass());
     }
 
     public function testClassReturnNoClassGivenReturnsNull()
     {
         $parameter = new Reflection\ParameterReflection(
-            ['ZendTest\Code\Reflection\TestAsset\TestSampleClass2', 'getProp2'],
+            [TestAsset\TestSampleClass2::class, 'getProp2'],
             'param1'
         );
         $this->assertNull($parameter->getClass());
@@ -42,10 +43,10 @@ class ParameterReflectionTest extends TestCase
     public function testClassReturn()
     {
         $parameter = new Reflection\ParameterReflection(
-            ['ZendTest\Code\Reflection\TestAsset\TestSampleClass2', 'getProp2'],
+            [TestAsset\TestSampleClass2::class, 'getProp2'],
             'param2'
         );
-        $this->assertInstanceOf('Zend\Code\Reflection\ClassReflection', $parameter->getClass());
+        $this->assertInstanceOf(ClassReflection::class, $parameter->getClass());
     }
 
     /**
@@ -54,7 +55,7 @@ class ParameterReflectionTest extends TestCase
     public function testTypeReturn($param, $type)
     {
         $parameter = new Reflection\ParameterReflection(
-            ['ZendTest\Code\Reflection\TestAsset\TestSampleClass5', 'doSomething'],
+            [TestAsset\TestSampleClass5::class, 'doSomething'],
             $param
         );
         $this->assertEquals($type, $parameter->detectType());
@@ -63,7 +64,7 @@ class ParameterReflectionTest extends TestCase
     public function testCallableTypeHint()
     {
         $parameter = new Reflection\ParameterReflection(
-            ['ZendTest\Code\Reflection\TestAsset\CallableTypeHintClass', 'foo'],
+            [TestAsset\CallableTypeHintClass::class, 'foo'],
             'bar'
         );
         $this->assertEquals('callable', $parameter->detectType());
@@ -72,11 +73,11 @@ class ParameterReflectionTest extends TestCase
     public function paramTypeTestProvider()
     {
         return [
-            ['one','int'],
-            ['two','int'],
-            ['three','string'],
-            ['array','array'],
-            ['class','ZendTest\Code\Reflection\TestAsset\TestSampleClass']
+            ['one', 'int'],
+            ['two', 'int'],
+            ['three', 'string'],
+            ['array', 'array'],
+            ['class', TestAsset\TestSampleClass::class],
         ];
     }
 
@@ -99,8 +100,8 @@ class ParameterReflectionTest extends TestCase
 
         $type = $reflection->getType();
 
-        self::assertInstanceOf(\ReflectionType::class, $type);
-        self::assertSame($expectedType, (string) $type);
+        $this->assertInstanceOf(\ReflectionType::class, $type);
+        $this->assertSame($expectedType, (string) $type);
     }
 
     /**
@@ -125,7 +126,7 @@ class ParameterReflectionTest extends TestCase
             $expectedType = $className;
         }
 
-        self::assertSame($expectedType, $reflection->detectType());
+        $this->assertSame($expectedType, $reflection->detectType());
     }
 
     /**
@@ -164,7 +165,7 @@ class ParameterReflectionTest extends TestCase
             $parameterName
         );
 
-        self::assertNull($reflection->getType());
+        $this->assertNull($reflection->getType());
     }
 
     /**
@@ -184,7 +185,7 @@ class ParameterReflectionTest extends TestCase
             $parameterName
         );
 
-        self::assertSame($expectedType, $reflection->detectType());
+        $this->assertSame($expectedType, $reflection->detectType());
     }
 
     /**

--- a/test/Reflection/ParameterReflectionTest.php
+++ b/test/Reflection/ParameterReflectionTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\Code\Reflection;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Code\Reflection;
 use ZendTest\Code\TestAsset\ClassTypeHintedClass;
 use ZendTest\Code\TestAsset\DocBlockOnlyHintsClass;
@@ -18,7 +19,7 @@ use ZendTest\Code\TestAsset\InternalHintsClass;
  * @group      Zend_Reflection
  * @group      Zend_Reflection_Parameter
  */
-class ParameterReflectionTest extends \PHPUnit_Framework_TestCase
+class ParameterReflectionTest extends TestCase
 {
     public function testDeclaringClassReturn()
     {

--- a/test/Reflection/ParameterReflectionTest.php
+++ b/test/Reflection/ParameterReflectionTest.php
@@ -83,8 +83,6 @@ class ParameterReflectionTest extends TestCase
     /**
      * @group zendframework/zend-code#29
      *
-     * @requires PHP 7.0
-     *
      * @dataProvider reflectionHintsProvider
      *
      * @param string $className
@@ -107,8 +105,6 @@ class ParameterReflectionTest extends TestCase
 
     /**
      * @group zendframework/zend-code#29
-     *
-     * @requires PHP 7.0
      *
      * @dataProvider reflectionHintsProvider
      *
@@ -154,8 +150,6 @@ class ParameterReflectionTest extends TestCase
 
     /**
      * @group zendframework/zend-code#29
-     *
-     * @requires PHP 7.0
      *
      * @dataProvider docBlockHintsProvider
      *

--- a/test/Reflection/PropertyReflectionTest.php
+++ b/test/Reflection/PropertyReflectionTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\Code\Reflection;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Code\Annotation\AnnotationManager;
 use Zend\Code\Annotation\Parser\GenericAnnotationParser;
 use Zend\Code\Reflection\ClassReflection;
@@ -19,7 +20,7 @@ use ZendTest\Code\Reflection\TestAsset\InjectablePropertyReflection;
  * @group      Zend_Reflection
  * @group      Zend_Reflection_Property
  */
-class PropertyReflectionTest extends \PHPUnit_Framework_TestCase
+class PropertyReflectionTest extends TestCase
 {
     public function testDeclaringClassReturn()
     {

--- a/test/Reflection/PropertyReflectionTest.php
+++ b/test/Reflection/PropertyReflectionTest.php
@@ -10,10 +10,12 @@
 namespace ZendTest\Code\Reflection;
 
 use PHPUnit\Framework\TestCase;
+use Zend\Code\Annotation\AnnotationCollection;
 use Zend\Code\Annotation\AnnotationManager;
 use Zend\Code\Annotation\Parser\GenericAnnotationParser;
 use Zend\Code\Reflection\ClassReflection;
 use Zend\Code\Reflection\PropertyReflection;
+use Zend\Code\Scanner\CachingFileScanner;
 use ZendTest\Code\Reflection\TestAsset\InjectablePropertyReflection;
 
 /**
@@ -38,7 +40,7 @@ class PropertyReflectionTest extends TestCase
 
         $property = new PropertyReflection(TestAsset\TestSampleClass2::class, '_prop2');
         $annotations = $property->getAnnotations($manager);
-        $this->assertInstanceOf('Zend\Code\Annotation\AnnotationCollection', $annotations);
+        $this->assertInstanceOf(AnnotationCollection::class, $annotations);
         $this->assertTrue($annotations->hasAnnotation(TestAsset\SampleAnnotation::class));
         $found = false;
         foreach ($annotations as $key => $annotation) {
@@ -57,13 +59,13 @@ class PropertyReflectionTest extends TestCase
         $reflectionProperty = new InjectablePropertyReflection(
             // TestSampleClass5 has the annotations required to get to the
             // right point in the getAnnotations method.
-            'ZendTest\Code\Reflection\TestAsset\TestSampleClass2',
+            TestAsset\TestSampleClass2::class,
             '_prop2'
         );
 
-        $annotationManager = new \Zend\Code\Annotation\AnnotationManager();
+        $annotationManager = new AnnotationManager();
 
-        $fileScanner = $this->getMockBuilder('Zend\Code\Scanner\CachingFileScanner')
+        $fileScanner = $this->getMockBuilder(CachingFileScanner::class)
                             ->disableOriginalConstructor()
                             ->getMock();
 

--- a/test/Reflection/ReflectionDocBlockTagTest.php
+++ b/test/Reflection/ReflectionDocBlockTagTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\Code\Reflection;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Code\Reflection;
 
 /**
@@ -16,7 +17,7 @@ use Zend\Code\Reflection;
  * @group      Zend_Reflection_DocBlock
  * @group      Zend_Reflection_DocBlock_Tag
  */
-class ReflectionDocBlockTagTest extends \PHPUnit_Framework_TestCase
+class ReflectionDocBlockTagTest extends TestCase
 {
     public function testTagDescriptionIsReturned()
     {

--- a/test/Reflection/ReflectionDocBlockTagTest.php
+++ b/test/Reflection/ReflectionDocBlockTagTest.php
@@ -21,7 +21,7 @@ class ReflectionDocBlockTagTest extends TestCase
 {
     public function testTagDescriptionIsReturned()
     {
-        $classReflection = new Reflection\ClassReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass5');
+        $classReflection = new Reflection\ClassReflection(TestAsset\TestSampleClass5::class);
 
         $authorTag = $classReflection->getDocBlock()->getTag('author');
         $this->assertEquals('Ralph Schindler', $authorTag->getAuthorName());
@@ -30,7 +30,7 @@ class ReflectionDocBlockTagTest extends TestCase
 
     public function testTagShouldAllowJustTagNameInDocBlockTagLine()
     {
-        $classReflection = new Reflection\ClassReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass6');
+        $classReflection = new Reflection\ClassReflection(TestAsset\TestSampleClass6::class);
 
         $tag = $classReflection->getMethod('doSomething')->getDocBlock()->getTag('emptyTag');
         $this->assertEquals($tag->getName(), 'emptyTag', 'Factory First Match Failed');
@@ -38,7 +38,7 @@ class ReflectionDocBlockTagTest extends TestCase
 
     public function testTagShouldAllowMultipleWhitespacesBeforeDescription()
     {
-        $classReflection = new Reflection\ClassReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass6');
+        $classReflection = new Reflection\ClassReflection(TestAsset\TestSampleClass6::class);
 
         $tag = $classReflection->getMethod('doSomething')->getDocBlock()->getTag('descriptionTag');
         $this->assertNotEquals('          A tag with just a description', $tag->getContent(), 'Final Match Failed');
@@ -47,7 +47,7 @@ class ReflectionDocBlockTagTest extends TestCase
 
     public function testToString()
     {
-        $classReflection = new Reflection\ClassReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass6');
+        $classReflection = new Reflection\ClassReflection(TestAsset\TestSampleClass6::class);
 
         $tag = $classReflection->getMethod('doSomething')->getDocBlock()->getTag('descriptionTag');
 
@@ -59,7 +59,7 @@ class ReflectionDocBlockTagTest extends TestCase
 
     public function testTypeParam()
     {
-        $classReflection = new Reflection\ClassReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass5');
+        $classReflection = new Reflection\ClassReflection(TestAsset\TestSampleClass5::class);
 
         $paramTag = $classReflection->getMethod('doSomething')->getDocBlock()->getTag('param');
 
@@ -68,7 +68,7 @@ class ReflectionDocBlockTagTest extends TestCase
 
     public function testVariableName()
     {
-        $classReflection = new Reflection\ClassReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass5');
+        $classReflection = new Reflection\ClassReflection(TestAsset\TestSampleClass5::class);
 
         $paramTag = $classReflection->getMethod('doSomething')->getDocBlock()->getTag('param');
         $this->assertEquals($paramTag->getVariableName(), '$one');
@@ -76,7 +76,7 @@ class ReflectionDocBlockTagTest extends TestCase
 
     public function testAllowsMultipleSpacesInDocBlockTagLine()
     {
-        $classReflection = new Reflection\ClassReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass6');
+        $classReflection = new Reflection\ClassReflection(TestAsset\TestSampleClass6::class);
 
         $paramTag = $classReflection->getMethod('doSomething')->getDocBlock()->getTag('param');
 
@@ -92,7 +92,7 @@ class ReflectionDocBlockTagTest extends TestCase
      */
     public function testNamespaceInParam()
     {
-        $classReflection = new Reflection\ClassReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass7');
+        $classReflection = new Reflection\ClassReflection(TestAsset\TestSampleClass7::class);
         $paramTag        = $classReflection->getMethod('doSomething')->getDocBlock()->getTag('param');
 
 
@@ -103,7 +103,7 @@ class ReflectionDocBlockTagTest extends TestCase
 
     public function testType()
     {
-        $classReflection = new Reflection\ClassReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass5');
+        $classReflection = new Reflection\ClassReflection(TestAsset\TestSampleClass5::class);
 
         $paramTag = $classReflection->getMethod('doSomething')->getDocBlock()->getTag('return');
         $this->assertEquals($paramTag->getType(), 'mixed');
@@ -111,7 +111,7 @@ class ReflectionDocBlockTagTest extends TestCase
 
     public function testAllowsMultipleSpacesInDocBlockTagLine2()
     {
-        $classReflection = new Reflection\ClassReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass6');
+        $classReflection = new Reflection\ClassReflection(TestAsset\TestSampleClass6::class);
 
         $paramTag = $classReflection->getMethod('doSomething')->getDocBlock()->getTag('return');
 
@@ -125,7 +125,7 @@ class ReflectionDocBlockTagTest extends TestCase
      */
     public function testReturnClassWithNamespace()
     {
-        $classReflection = new Reflection\ClassReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass7');
+        $classReflection = new Reflection\ClassReflection(TestAsset\TestSampleClass7::class);
 
         $paramTag = $classReflection->getMethod('doSomething')->getDocBlock()->getTag('return');
 

--- a/test/Reflection/TestAsset/TestSampleClass11.php
+++ b/test/Reflection/TestAsset/TestSampleClass11.php
@@ -58,11 +58,11 @@ class TestSampleClass11
         foreach($args as $arg) {
             if (is_array($arg)) {
                 foreach ($arg as $argElement) {
-                    $cacheKey = hash("sha256", $cacheKey.$argElement);
+                    $cacheKey = hash('sha256', $cacheKey.$argElement);
                 }
             }
             else {
-                $cacheKey = hash("sha256", $cacheKey.$arg);
+                $cacheKey = hash('sha256', $cacheKey.$arg);
             }
             //blah
         }

--- a/test/Scanner/AggregateDirectoryScannerTest.php
+++ b/test/Scanner/AggregateDirectoryScannerTest.php
@@ -9,9 +9,9 @@
 
 namespace ZendTest\Code\Scanner;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class AggregateDirectoryScannerTest extends PHPUnit_Framework_TestCase
+class AggregateDirectoryScannerTest extends TestCase
 {
     public function testAggregationOfDirectories()
     {

--- a/test/Scanner/AnnotationScannerTest.php
+++ b/test/Scanner/AnnotationScannerTest.php
@@ -9,12 +9,13 @@
 
 namespace ZendTest\Code\Scanner;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Code\Scanner\AnnotationScanner;
 use Zend\Code\NameInformation;
 use Zend\Code\Annotation\AnnotationManager;
 use Zend\Code\Annotation\Parser\GenericAnnotationParser;
 
-class AnnotationScannerTest extends \PHPUnit_Framework_TestCase
+class AnnotationScannerTest extends TestCase
 {
     /**
      * @dataProvider scannerWorksDataProvider

--- a/test/Scanner/AnnotationScannerTest.php
+++ b/test/Scanner/AnnotationScannerTest.php
@@ -10,10 +10,10 @@
 namespace ZendTest\Code\Scanner;
 
 use PHPUnit\Framework\TestCase;
-use Zend\Code\Scanner\AnnotationScanner;
-use Zend\Code\NameInformation;
 use Zend\Code\Annotation\AnnotationManager;
 use Zend\Code\Annotation\Parser\GenericAnnotationParser;
+use Zend\Code\NameInformation;
+use Zend\Code\Scanner\AnnotationScanner;
 
 class AnnotationScannerTest extends TestCase
 {
@@ -33,7 +33,7 @@ class AnnotationScannerTest extends TestCase
         $docComment = '/**' . $newLine
             . ' * @Test\Foo(\'anything I want()' . $newLine
             . ' * to be\')' . $newLine
-            . ' * @Test\Bar' . $newLine . " */";
+            . ' * @Test\Bar' . $newLine . ' */';
 
         $nameInfo = new NameInformation();
         $nameInfo->addUse('ZendTest\Code\Scanner\TestAsset\Annotation', 'Test');

--- a/test/Scanner/CachingFileScannerTest.php
+++ b/test/Scanner/CachingFileScannerTest.php
@@ -10,8 +10,9 @@
 namespace ZendTest\Code\Scanner;
 
 use PHPUnit\Framework\TestCase;
-use Zend\Code\Scanner\CachingFileScanner;
 use Zend\Code\Annotation\AnnotationManager;
+use Zend\Code\Scanner\CachingFileScanner;
+use ZendTest\Code\TestAsset\BarClass;
 
 class CachingFileScannerTest extends TestCase
 {
@@ -26,7 +27,7 @@ class CachingFileScannerTest extends TestCase
 
         // single entry, based on file
         $cfs1 = new CachingFileScanner(__DIR__ . '/../TestAsset/BarClass.php');
-        $this->assertContains('ZendTest\Code\TestAsset\BarClass', $cfs1->getClassNames());
+        $this->assertContains(BarClass::class, $cfs1->getClassNames());
         $this->assertEquals(1, $this->getCacheCount($cfs1));
 
         // ensure same class is used internally

--- a/test/Scanner/CachingFileScannerTest.php
+++ b/test/Scanner/CachingFileScannerTest.php
@@ -9,10 +9,11 @@
 
 namespace ZendTest\Code\Scanner;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Code\Scanner\CachingFileScanner;
 use Zend\Code\Annotation\AnnotationManager;
 
-class CachingFileScannerTest extends \PHPUnit_Framework_TestCase
+class CachingFileScannerTest extends TestCase
 {
     protected function setUp()
     {

--- a/test/Scanner/ClassScannerTest.php
+++ b/test/Scanner/ClassScannerTest.php
@@ -9,12 +9,13 @@
 
 namespace ZendTest\Code\Scanner;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\Code\Annotation;
 use Zend\Code\Scanner\FileScanner;
 use Zend\Stdlib\ErrorHandler;
 use ZendTest\Code\TestAsset\TraitWithSameMethods;
 use ZendTest\Code\TestAsset\TestClassWithTraitAliases;
+use Zend\Code\Exception\RuntimeException;
 
 class ClassScannerTest extends TestCase
 {
@@ -268,11 +269,10 @@ class ClassScannerTest extends TestCase
      */
     public function testGetMethodsThrowsExceptionOnDuplicateMethods()
     {
-        $this->setExpectedException('Zend\Code\Exception\RuntimeException');
-
         $file  = new FileScanner(__DIR__ . '/TestAsset/TestClassWithAliasException.php');
         $class = $file->getClass('ZendTest\Code\Scanner\TestAsset\TestClassWithAliasException');
 
+        $this->expectException(RuntimeException::class);
         $class->getMethods();
     }
 

--- a/test/Scanner/ClassScannerTest.php
+++ b/test/Scanner/ClassScannerTest.php
@@ -218,7 +218,7 @@ class ClassScannerTest extends TestCase
 
         $aliases = $class->getTraitAliases();
 
-        $this->assertEquals(count($aliases), 1);
+        $this->assertCount(1, $aliases);
 
         $this->assertEquals(key($aliases), 'test');
         $this->assertEquals(current($aliases), 'ZendTest\Code\TestAsset\TraitWithSameMethods::foo');
@@ -313,7 +313,7 @@ class ClassScannerTest extends TestCase
         $file  = new FileScanner(__DIR__ . '/../TestAsset/FooInterface.php');
         $class = $file->getClass('ZendTest\Code\TestAsset\FooInterface');
         $this->assertTrue($class->isInterface());
-        $this->assertEquals(1, count($class->getInterfaces()));
+        $this->assertCount(1, $class->getInterfaces());
         $this->assertEquals('ArrayAccess', $class->getInterfaces()[0]);
     }
 }

--- a/test/Scanner/ClassScannerTest.php
+++ b/test/Scanner/ClassScannerTest.php
@@ -11,11 +11,23 @@ namespace ZendTest\Code\Scanner;
 
 use PHPUnit\Framework\TestCase;
 use Zend\Code\Annotation;
-use Zend\Code\Scanner\FileScanner;
-use Zend\Stdlib\ErrorHandler;
-use ZendTest\Code\TestAsset\TraitWithSameMethods;
-use ZendTest\Code\TestAsset\TestClassWithTraitAliases;
 use Zend\Code\Exception\RuntimeException;
+use Zend\Code\Scanner\ConstantScanner;
+use Zend\Code\Scanner\FileScanner;
+use Zend\Code\Scanner\MethodScanner;
+use Zend\Code\Scanner\PropertyScanner;
+use Zend\Stdlib\ErrorHandler;
+use ZendTest\Code\Annotation\TestAsset\Bar;
+use ZendTest\Code\Annotation\TestAsset\EntityWithAnnotations;
+use ZendTest\Code\Annotation\TestAsset\Foo;
+use ZendTest\Code\TestAsset\BarClass;
+use ZendTest\Code\TestAsset\BarTrait;
+use ZendTest\Code\TestAsset\BazTrait;
+use ZendTest\Code\TestAsset\FooClass;
+use ZendTest\Code\TestAsset\FooInterface;
+use ZendTest\Code\TestAsset\FooTrait;
+use ZendTest\Code\TestAsset\TestClassUsesTraitSimple;
+use ZendTest\Code\TestAsset\TestClassWithTraitAliases;
 
 class ClassScannerTest extends TestCase
 {
@@ -26,8 +38,8 @@ class ClassScannerTest extends TestCase
         $this->manager = new Annotation\AnnotationManager();
 
         $genericParser = new Annotation\Parser\GenericAnnotationParser();
-        $genericParser->registerAnnotation('ZendTest\Code\Annotation\TestAsset\Foo');
-        $genericParser->registerAnnotation('ZendTest\Code\Annotation\TestAsset\Bar');
+        $genericParser->registerAnnotation(Foo::class);
+        $genericParser->registerAnnotation(Bar::class);
 
         $this->manager->attach($genericParser);
     }
@@ -35,8 +47,8 @@ class ClassScannerTest extends TestCase
     public function testClassScannerHasClassInformation()
     {
         $file  = new FileScanner(__DIR__ . '/../TestAsset/FooClass.php');
-        $class = $file->getClass('ZendTest\Code\TestAsset\FooClass');
-        $this->assertEquals('ZendTest\Code\TestAsset\FooClass', $class->getName());
+        $class = $file->getClass(FooClass::class);
+        $this->assertEquals(FooClass::class, $class->getName());
         $this->assertEquals('FooClass', $class->getShortName());
         $this->assertFalse($class->isFinal());
         $this->assertTrue($class->isAbstract());
@@ -53,7 +65,7 @@ class ClassScannerTest extends TestCase
     public function testClassScannerHasConstant()
     {
         $file  = new FileScanner(__DIR__ . '/../TestAsset/FooClass.php');
-        $class = $file->getClass('ZendTest\Code\TestAsset\FooClass');
+        $class = $file->getClass(FooClass::class);
         $this->assertInternalType('array', $class->getConstantNames());
         $this->assertContains('FOO', $class->getConstantNames());
     }
@@ -61,14 +73,14 @@ class ClassScannerTest extends TestCase
     public function testClassScannerHasProperties()
     {
         $file  = new FileScanner(__DIR__ . '/../TestAsset/FooClass.php');
-        $class = $file->getClass('ZendTest\Code\TestAsset\FooClass');
+        $class = $file->getClass(FooClass::class);
         $this->assertContains('bar', $class->getPropertyNames());
     }
 
     public function testClassScannerHasMethods()
     {
         $file  = new FileScanner(__DIR__ . '/../TestAsset/FooClass.php');
-        $class = $file->getClass('ZendTest\Code\TestAsset\FooClass');
+        $class = $file->getClass(FooClass::class);
         $this->assertContains('fooBarBaz', $class->getMethodNames());
     }
 
@@ -78,30 +90,30 @@ class ClassScannerTest extends TestCase
     public function testGetConstantsReturnsConstantNames()
     {
         $file      = new FileScanner(__DIR__ . '/../TestAsset/FooClass.php');
-        $class     = $file->getClass('ZendTest\Code\TestAsset\FooClass');
+        $class     = $file->getClass(FooClass::class);
 
         ErrorHandler::start(E_USER_DEPRECATED);
         $constants = $class->getConstants();
         $error = ErrorHandler::stop();
 
-        $this->assertInstanceOf('ErrorException', $error);
+        $this->assertInstanceOf(\ErrorException::class, $error);
         $this->assertContains('FOO', $constants);
     }
 
     public function testGetConstantsReturnsInstancesOfConstantScanner()
     {
         $file    = new FileScanner(__DIR__ . '/../TestAsset/FooClass.php');
-        $class   = $file->getClass('ZendTest\Code\TestAsset\FooClass');
+        $class   = $file->getClass(FooClass::class);
         $constants = $class->getConstants(false);
         foreach ($constants as $constant) {
-            $this->assertInstanceOf('Zend\Code\Scanner\ConstantScanner', $constant);
+            $this->assertInstanceOf(ConstantScanner::class, $constant);
         }
     }
 
     public function testHasConstant()
     {
         $file    = new FileScanner(__DIR__ . '/../TestAsset/FooClass.php');
-        $class   = $file->getClass('ZendTest\Code\TestAsset\FooClass');
+        $class   = $file->getClass(FooClass::class);
         $this->assertTrue($class->hasConstant('FOO'));
         $this->assertFalse($class->hasConstant('foo'));
     }
@@ -109,7 +121,7 @@ class ClassScannerTest extends TestCase
     public function testHasProperty()
     {
         $file    = new FileScanner(__DIR__ . '/../TestAsset/FooClass.php');
-        $class   = $file->getClass('ZendTest\Code\TestAsset\FooClass');
+        $class   = $file->getClass(FooClass::class);
         $this->assertTrue($class->hasProperty('foo'));
         $this->assertFalse($class->hasProperty('FOO'));
         $this->assertTrue($class->hasProperty('bar'));
@@ -118,7 +130,7 @@ class ClassScannerTest extends TestCase
     public function testHasMethod()
     {
         $file    = new FileScanner(__DIR__ . '/../TestAsset/FooClass.php');
-        $class   = $file->getClass('ZendTest\Code\TestAsset\FooClass');
+        $class   = $file->getClass(FooClass::class);
         $this->assertTrue($class->hasMethod('fooBarBaz'));
         $this->assertFalse($class->hasMethod('FooBarBaz'));
         $this->assertFalse($class->hasMethod('bar'));
@@ -127,39 +139,39 @@ class ClassScannerTest extends TestCase
     public function testClassScannerReturnsMethodsWithMethodScanners()
     {
         $file    = new FileScanner(__DIR__ . '/../TestAsset/FooClass.php');
-        $class   = $file->getClass('ZendTest\Code\TestAsset\FooClass');
+        $class   = $file->getClass(FooClass::class);
         $methods = $class->getMethods();
         foreach ($methods as $method) {
-            $this->assertInstanceOf('Zend\Code\Scanner\MethodScanner', $method);
+            $this->assertInstanceOf(MethodScanner::class, $method);
         }
     }
 
     public function testClassScannerReturnsPropertiesWithPropertyScanners()
     {
         $file    = new FileScanner(__DIR__ . '/../TestAsset/FooClass.php');
-        $class   = $file->getClass('ZendTest\Code\TestAsset\FooClass');
+        $class   = $file->getClass(FooClass::class);
         $properties = $class->getProperties();
         foreach ($properties as $property) {
-            $this->assertInstanceOf('Zend\Code\Scanner\PropertyScanner', $property);
+            $this->assertInstanceOf(PropertyScanner::class, $property);
         }
     }
 
     public function testClassScannerCanScanInterface()
     {
         $file  = new FileScanner(__DIR__ . '/../TestAsset/FooInterface.php');
-        $class = $file->getClass('ZendTest\Code\TestAsset\FooInterface');
-        $this->assertEquals('ZendTest\Code\TestAsset\FooInterface', $class->getName());
+        $class = $file->getClass(FooInterface::class);
+        $this->assertEquals(FooInterface::class, $class->getName());
     }
 
     public function testClassScannerCanReturnLineNumbers()
     {
         $file    = new FileScanner(__DIR__ . '/../TestAsset/FooClass.php');
-        $class   = $file->getClass('ZendTest\Code\TestAsset\FooClass');
+        $class   = $file->getClass(FooClass::class);
         $this->assertEquals(11, $class->getLineStart());
         $this->assertEquals(36, $class->getLineEnd());
 
         $file    = new FileScanner(__DIR__ . '/../TestAsset/BarClass.php');
-        $class   = $file->getClass('ZendTest\Code\TestAsset\BarClass');
+        $class   = $file->getClass(BarClass::class);
         $this->assertEquals(10, $class->getLineStart());
         $this->assertEquals(42, $class->getLineEnd());
     }
@@ -167,11 +179,11 @@ class ClassScannerTest extends TestCase
     public function testClassScannerCanScanAnnotations()
     {
         $file    = new FileScanner(__DIR__ . '/../Annotation/TestAsset/EntityWithAnnotations.php');
-        $class   = $file->getClass('ZendTest\Code\Annotation\TestAsset\EntityWithAnnotations');
+        $class   = $file->getClass(EntityWithAnnotations::class);
         $annotations = $class->getAnnotations($this->manager);
 
-        $this->assertTrue($annotations->hasAnnotation('ZendTest\Code\Annotation\TestAsset\Foo'));
-        $this->assertTrue($annotations->hasAnnotation('ZendTest\Code\Annotation\TestAsset\Bar'));
+        $this->assertTrue($annotations->hasAnnotation(Foo::class));
+        $this->assertTrue($annotations->hasAnnotation(Bar::class));
 
         $this->assertEquals('first', $annotations[0]->content);
         $this->assertEquals('second', $annotations[1]->content);
@@ -184,7 +196,7 @@ class ClassScannerTest extends TestCase
     public function testClassScannerCanScanTraits()
     {
         $file  = new FileScanner(__DIR__ . '/../TestAsset/BarTrait.php');
-        $class = $file->getClass('ZendTest\Code\TestAsset\BarTrait');
+        $class = $file->getClass(BarTrait::class);
 
         $this->assertTrue($class->isTrait());
         $this->assertTrue($class->hasMethod('bar'));
@@ -196,14 +208,14 @@ class ClassScannerTest extends TestCase
     public function testClassScannerCanScanClassThatUsesTraits()
     {
         $file  = new FileScanner(__DIR__ . '/../TestAsset/TestClassUsesTraitSimple.php');
-        $class = $file->getClass('ZendTest\Code\TestAsset\TestClassUsesTraitSimple');
+        $class = $file->getClass(TestClassUsesTraitSimple::class);
 
         $this->assertFalse($class->isTrait());
         $traitNames = $class->getTraitNames();
         $class->getTraitAliases();
-        $this->assertContains('ZendTest\Code\TestAsset\BarTrait', $traitNames);
-        $this->assertContains('ZendTest\Code\TestAsset\FooTrait', $traitNames);
-        $this->assertContains('ZendTest\Code\TestAsset\BazTrait', $traitNames);
+        $this->assertContains(BarTrait::class, $traitNames);
+        $this->assertContains(FooTrait::class, $traitNames);
+        $this->assertContains(BazTrait::class, $traitNames);
     }
 
     /**
@@ -212,7 +224,7 @@ class ClassScannerTest extends TestCase
     public function testClassScannerCanScanClassAndGetTraitsAliases()
     {
         $file  = new FileScanner(__DIR__ . '/../TestAsset/TestClassWithTraitAliases.php');
-        $class = $file->getClass('ZendTest\Code\TestAsset\TestClassWithTraitAliases');
+        $class = $file->getClass(TestClassWithTraitAliases::class);
 
         $this->assertFalse($class->isTrait());
 
@@ -230,12 +242,12 @@ class ClassScannerTest extends TestCase
     public function testClassScannerCanGetTraitMethodsInGetMethods()
     {
         //load files or test may fail due to autoload issues
-        require_once(__DIR__ . '/../TestAsset/TraitWithSameMethods.php');
-        require_once(__DIR__ . '/../TestAsset/BarTrait.php');
+        require_once __DIR__ . '/../TestAsset/TraitWithSameMethods.php';
+        require_once __DIR__ . '/../TestAsset/BarTrait.php';
 
         $file  = new FileScanner(__DIR__ . '/../TestAsset/TestClassWithTraitAliases.php');
 
-        $class = $file->getClass('ZendTest\Code\TestAsset\TestClassWithTraitAliases');
+        $class = $file->getClass(TestClassWithTraitAliases::class);
 
         $this->assertFalse($class->isTrait());
 
@@ -253,12 +265,12 @@ class ClassScannerTest extends TestCase
             $this->assertTrue($class->hasMethod($methodName), "Cannot find method $methodName");
 
             $method = $class->getMethod($methodName);
-            $this->assertInstanceOf('Zend\Code\Scanner\MethodScanner', $method, $methodName . ' not found.');
+            $this->assertInstanceOf(MethodScanner::class, $method, $methodName . ' not found.');
 
             $this->assertTrue($method->$testMethod());
 
             // test that we got the right ::bar method based on declaration
-            if ($testMethod === "bar") {
+            if ($testMethod === 'bar') {
                 $this->assertEquals(trim($method->getBody), 'echo "foo";');
             }
         }
@@ -270,7 +282,7 @@ class ClassScannerTest extends TestCase
     public function testGetMethodsThrowsExceptionOnDuplicateMethods()
     {
         $file  = new FileScanner(__DIR__ . '/TestAsset/TestClassWithAliasException.php');
-        $class = $file->getClass('ZendTest\Code\Scanner\TestAsset\TestClassWithAliasException');
+        $class = $file->getClass(TestAsset\TestClassWithAliasException::class);
 
         $this->expectException(RuntimeException::class);
         $class->getMethods();
@@ -287,7 +299,7 @@ class ClassScannerTest extends TestCase
     public function testAbstractClassIsNotInstantiable()
     {
         $file  = new FileScanner(__DIR__ . '/../TestAsset/FooClass.php');
-        $class = $file->getClass('ZendTest\Code\TestAsset\FooClass');
+        $class = $file->getClass(FooClass::class);
         $this->assertTrue($class->isAbstract());
         $this->assertFalse($class->isInstantiable());
     }
@@ -295,7 +307,7 @@ class ClassScannerTest extends TestCase
     public function testInterfaceIsNotInstantiable()
     {
         $file  = new FileScanner(__DIR__ . '/../TestAsset/FooInterface.php');
-        $class = $file->getClass('ZendTest\Code\TestAsset\FooInterface');
+        $class = $file->getClass(FooInterface::class);
         $this->assertTrue($class->isInterface());
         $this->assertFalse($class->isInstantiable());
     }
@@ -303,7 +315,7 @@ class ClassScannerTest extends TestCase
     public function testTraitIsNotInstantiable()
     {
         $file  = new FileScanner(__DIR__ . '/../TestAsset/FooTrait.php');
-        $class = $file->getClass('ZendTest\Code\TestAsset\FooTrait');
+        $class = $file->getClass(FooTrait::class);
         $this->assertTrue($class->isTrait());
         $this->assertFalse($class->isInstantiable());
     }
@@ -311,7 +323,7 @@ class ClassScannerTest extends TestCase
     public function testGetInterfacesFromInterface()
     {
         $file  = new FileScanner(__DIR__ . '/../TestAsset/FooInterface.php');
-        $class = $file->getClass('ZendTest\Code\TestAsset\FooInterface');
+        $class = $file->getClass(FooInterface::class);
         $this->assertTrue($class->isInterface());
         $this->assertCount(1, $class->getInterfaces());
         $this->assertEquals('ArrayAccess', $class->getInterfaces()[0]);

--- a/test/Scanner/ConstantScannerTest.php
+++ b/test/Scanner/ConstantScannerTest.php
@@ -9,15 +9,16 @@
 
 namespace ZendTest\Code\Scanner;
 
-use Zend\Code\Scanner\FileScanner;
 use PHPUnit\Framework\TestCase;
+use Zend\Code\Scanner\FileScanner;
+use ZendTest\Code\TestAsset\FooClass;
 
 class ConstantScannerTest extends TestCase
 {
     public function testConstantScannerHasConstantInformation()
     {
         $file = new FileScanner(__DIR__ . '/../TestAsset/FooClass.php');
-        $class = $file->getClass('ZendTest\Code\TestAsset\FooClass');
+        $class = $file->getClass(FooClass::class);
 
         $constant = $class->getConstant('BAR');
         $this->assertEquals('BAR', $constant->getName());

--- a/test/Scanner/ConstantScannerTest.php
+++ b/test/Scanner/ConstantScannerTest.php
@@ -10,7 +10,7 @@
 namespace ZendTest\Code\Scanner;
 
 use Zend\Code\Scanner\FileScanner;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 class ConstantScannerTest extends TestCase
 {

--- a/test/Scanner/DerivedClassScannerTest.php
+++ b/test/Scanner/DerivedClassScannerTest.php
@@ -9,10 +9,11 @@
 
 namespace ZendTest\Code\Scanner;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Code\Scanner\DirectoryScanner;
 use Zend\Code\Scanner\AggregateDirectoryScanner;
 
-class DerivedClassScannerTest extends \PHPUnit_Framework_TestCase
+class DerivedClassScannerTest extends TestCase
 {
     public function testCreatesClass()
     {

--- a/test/Scanner/DerivedClassScannerTest.php
+++ b/test/Scanner/DerivedClassScannerTest.php
@@ -10,8 +10,8 @@
 namespace ZendTest\Code\Scanner;
 
 use PHPUnit\Framework\TestCase;
-use Zend\Code\Scanner\DirectoryScanner;
 use Zend\Code\Scanner\AggregateDirectoryScanner;
+use Zend\Code\Scanner\DirectoryScanner;
 
 class DerivedClassScannerTest extends TestCase
 {
@@ -21,7 +21,7 @@ class DerivedClassScannerTest extends TestCase
         $ds->addDirectory(__DIR__ . '/TestAsset');
         $ads = new AggregateDirectoryScanner();
         $ads->addDirectoryScanner($ds);
-        $c = $ads->getClass('ZendTest\Code\Scanner\TestAsset\MapperExample\RepositoryB');
-        $this->assertEquals('ZendTest\Code\Scanner\TestAsset\MapperExample\RepositoryB', $c->getName());
+        $c = $ads->getClass(TestAsset\MapperExample\RepositoryB::class);
+        $this->assertEquals(TestAsset\MapperExample\RepositoryB::class, $c->getName());
     }
 }

--- a/test/Scanner/DocBlockScannerTest.php
+++ b/test/Scanner/DocBlockScannerTest.php
@@ -9,8 +9,8 @@
 
 namespace ZendTest\Code\Scanner;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Code\Scanner\DocBlockScanner;
-use PHPUnit_Framework_TestCase as TestCase;
 
 /**
  * @group      Zend_Code_Scanner

--- a/test/Scanner/FileScannerTest.php
+++ b/test/Scanner/FileScannerTest.php
@@ -11,16 +11,14 @@ namespace ZendTest\Code\Scanner;
 
 use PHPUnit\Framework\TestCase;
 use Zend\Code\Scanner\FileScanner;
+use ZendTest\Code\TestAsset\Baz;
 
 class FileScannerTest extends TestCase
 {
     public function testFileScannerCanReturnClasses()
     {
         $tokenScanner = new FileScanner(__DIR__ . '/../TestAsset/MultipleNamespaces.php');
-        $this->assertEquals(
-            'ZendTest\Code\TestAsset\Baz',
-            $tokenScanner->getClass('ZendTest\Code\TestAsset\Baz')->getName()
-        );
+        $this->assertEquals(Baz::class, $tokenScanner->getClass(Baz::class)->getName());
         $this->assertEquals('Foo', $tokenScanner->getClass('Foo')->getName());
     }
 }

--- a/test/Scanner/FileScannerTest.php
+++ b/test/Scanner/FileScannerTest.php
@@ -9,8 +9,8 @@
 
 namespace ZendTest\Code\Scanner;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Code\Scanner\FileScanner;
-use PHPUnit_Framework_TestCase as TestCase;
 
 class FileScannerTest extends TestCase
 {

--- a/test/Scanner/MethodScannerTest.php
+++ b/test/Scanner/MethodScannerTest.php
@@ -11,13 +11,17 @@ namespace ZendTest\Code\Scanner;
 
 use PHPUnit\Framework\TestCase;
 use Zend\Code\Scanner\FileScanner;
+use Zend\Code\Scanner\ParameterScanner;
+use ZendTest\Code\TestAsset\AbstractClass;
+use ZendTest\Code\TestAsset\BarClass;
+use ZendTest\Code\TestAsset\FooClass;
 
 class MethodScannerTest extends TestCase
 {
     public function testMethodScannerHasMethodInformation()
     {
         $file   = new FileScanner(__DIR__ . '/../TestAsset/FooClass.php');
-        $class  = $file->getClass('ZendTest\Code\TestAsset\FooClass');
+        $class  = $file->getClass(FooClass::class);
         $method = $class->getMethod('fooBarBaz');
         $this->assertEquals('fooBarBaz', $method->getName());
         $this->assertFalse($method->isAbstract());
@@ -31,7 +35,7 @@ class MethodScannerTest extends TestCase
     public function testMethodScannerReturnsParameters()
     {
         $file       = new FileScanner(__DIR__ . '/../TestAsset/BarClass.php');
-        $class      = $file->getClass('ZendTest\Code\TestAsset\BarClass');
+        $class      = $file->getClass(BarClass::class);
         $method     = $class->getMethod('three');
         $parameters = $method->getParameters();
         $this->assertInternalType('array', $parameters);
@@ -40,22 +44,22 @@ class MethodScannerTest extends TestCase
     public function testMethodScannerReturnsParameterScanner()
     {
         $file   = new FileScanner(__DIR__ . '/../TestAsset/BarClass.php');
-        $class  = $file->getClass('ZendTest\Code\TestAsset\BarClass');
+        $class  = $file->getClass(BarClass::class);
         $method = $class->getMethod('three');
         $this->assertEquals(['o', 't', 'bbf'], $method->getParameters());
         $parameter = $method->getParameter('t');
-        $this->assertInstanceOf('Zend\Code\Scanner\ParameterScanner', $parameter);
+        $this->assertInstanceOf(ParameterScanner::class, $parameter);
         $this->assertEquals('t', $parameter->getName());
     }
 
     public function testMethodScannerParsesClassNames()
     {
         $file   = new FileScanner(__DIR__ . '/../TestAsset/BarClass.php');
-        $class  = $file->getClass('ZendTest\Code\TestAsset\BarClass');
+        $class  = $file->getClass(BarClass::class);
         $method = $class->getMethod('five');
         $this->assertEquals(['a'], $method->getParameters());
         $parameter = $method->getParameter('a');
-        $this->assertEquals('ZendTest\Code\TestAsset\AbstractClass', $parameter->getClass());
+        $this->assertEquals(AbstractClass::class, $parameter->getClass());
     }
 
     public function testMethodScannerReturnsPropertyWithNoDefault()
@@ -69,7 +73,7 @@ class MethodScannerTest extends TestCase
     public function testMethodScannerReturnsLineNumbersForMethods()
     {
         $file       = new FileScanner(__DIR__ . '/../TestAsset/BarClass.php');
-        $class      = $file->getClass('ZendTest\Code\TestAsset\BarClass');
+        $class      = $file->getClass(BarClass::class);
         $method     = $class->getMethod('three');
         $this->assertEquals(27, $method->getLineStart());
         $this->assertEquals(31, $method->getLineEnd());
@@ -78,7 +82,7 @@ class MethodScannerTest extends TestCase
     public function testMethodScannerReturnsBodyMethods()
     {
         $file     = new FileScanner(__DIR__ . '/../TestAsset/BarClass.php');
-        $class    = $file->getClass('ZendTest\Code\TestAsset\BarClass');
+        $class    = $file->getClass(BarClass::class);
         $method   = $class->getMethod('three');
         $expected = "\n" . '        $x = 5 + 5;' . "\n" . '        $y = \'this string\';' . "\n    ";
         $this->assertEquals($expected, $method->getBody());
@@ -87,7 +91,7 @@ class MethodScannerTest extends TestCase
     public function testMethodScannerMethodSignatureLatestOptionalParamHasParentheses()
     {
         $file       = new FileScanner(__DIR__ . '/../TestAsset/BarClass.php');
-        $class      = $file->getClass('ZendTest\Code\TestAsset\BarClass');
+        $class      = $file->getClass(BarClass::class);
         $method = $class->getMethod('four');
         $paramTwo = $method->getParameter(1);
         $optionalValue = $paramTwo->getDefaultValue();
@@ -101,7 +105,7 @@ class MethodScannerTest extends TestCase
     {
         $file = new FileScanner(__DIR__ . '/../TestAsset/AbstractClass.php');
 
-        $class = $file->getClass('ZendTest\Code\TestAsset\AbstractClass');
+        $class = $file->getClass(AbstractClass::class);
         $method = $class->getMethod('helloWorld');
 
         $this->assertTrue($method->isAbstract());

--- a/test/Scanner/MethodScannerTest.php
+++ b/test/Scanner/MethodScannerTest.php
@@ -9,8 +9,8 @@
 
 namespace ZendTest\Code\Scanner;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Code\Scanner\FileScanner;
-use PHPUnit_Framework_TestCase as TestCase;
 
 class MethodScannerTest extends TestCase
 {

--- a/test/Scanner/ParameterScannerTest.php
+++ b/test/Scanner/ParameterScannerTest.php
@@ -11,16 +11,17 @@ namespace ZendTest\Code\Scanner;
 
 use PHPUnit\Framework\TestCase;
 use Zend\Code\Scanner\FileScanner;
+use ZendTest\Code\TestAsset\BarClass;
 
 class ParameterScannerTest extends TestCase
 {
     public function testParameterScannerHasParameterInformation()
     {
         $file      = new FileScanner(__DIR__ . '/../TestAsset/BarClass.php');
-        $class     = $file->getClass('ZendTest\Code\TestAsset\BarClass');
+        $class     = $file->getClass(BarClass::class);
         $method    = $class->getMethod('three');
         $parameter = $method->getParameter('t');
-        $this->assertEquals('ZendTest\Code\TestAsset\BarClass', $parameter->getDeclaringClass());
+        $this->assertEquals(BarClass::class, $parameter->getDeclaringClass());
         $this->assertEquals('three', $parameter->getDeclaringFunction());
         $this->assertEquals('t', $parameter->getName());
         $this->assertEquals(2, $parameter->getPosition());

--- a/test/Scanner/ParameterScannerTest.php
+++ b/test/Scanner/ParameterScannerTest.php
@@ -9,8 +9,8 @@
 
 namespace ZendTest\Code\Scanner;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Code\Scanner\FileScanner;
-use PHPUnit_Framework_TestCase as TestCase;
 
 class ParameterScannerTest extends TestCase
 {

--- a/test/Scanner/PropertyScannerTest.php
+++ b/test/Scanner/PropertyScannerTest.php
@@ -12,13 +12,14 @@ namespace ZendTest\Code\Scanner;
 use PHPUnit\Framework\TestCase;
 use Zend\Code\Scanner\FileScanner;
 use Zend\Code\Scanner\TokenArrayScanner;
+use ZendTest\Code\TestAsset\FooClass;
 
 class PropertyScannerTest extends TestCase
 {
     public function testPropertyScannerHasPropertyInformation()
     {
         $file = new FileScanner(__DIR__ . '/../TestAsset/FooClass.php');
-        $class = $file->getClass('ZendTest\Code\TestAsset\FooClass');
+        $class = $file->getClass(FooClass::class);
 
         $property = $class->getProperty('bar');
         $this->assertEquals('bar', $property->getName());
@@ -70,30 +71,30 @@ CLASS;
             $value = $property->getValue();
             $valueType = $property->getValueType();
             switch ($property->getName()) {
-                case "empty":
+                case 'empty':
                     $this->assertNull($value);
                     $this->assertEquals('unknown', $valueType);
                     break;
-                case "string":
+                case 'string':
                     $this->assertEquals('string', $value);
                     $this->assertEquals('string', $valueType);
                     break;
-                case "int":
+                case 'int':
                     $this->assertEquals('123', $value);
                     $this->assertEquals('int', $valueType);
                     break;
-                case "array":
+                case 'array':
                     $this->assertEquals("array('test'=>2,2)", $value);
                     $this->assertEquals('array', $valueType);
                     break;
-                case "arraynew":
+                case 'arraynew':
                     $this->assertEquals("['test'=>2,2]", $value);
                     $this->assertEquals('array', $valueType);
                     break;
-                case "notarray":
+                case 'notarray':
                     $this->assertEquals('string', $valueType);
                     break;
-                case "status":
+                case 'status':
                     $this->assertEquals('false', $value);
                     $this->assertEquals('boolean', $valueType);
                     break;

--- a/test/Scanner/PropertyScannerTest.php
+++ b/test/Scanner/PropertyScannerTest.php
@@ -9,9 +9,9 @@
 
 namespace ZendTest\Code\Scanner;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Code\Scanner\FileScanner;
 use Zend\Code\Scanner\TokenArrayScanner;
-use PHPUnit_Framework_TestCase as TestCase;
 
 class PropertyScannerTest extends TestCase
 {

--- a/test/Scanner/TestAsset/TestClassWithAliasException.php
+++ b/test/Scanner/TestAsset/TestClassWithAliasException.php
@@ -1,11 +1,11 @@
 <?php
 namespace ZendTest\Code\Scanner\TestAsset;
 
-require_once(__DIR__ . '/TraitWithSameMethods.php');
-require_once(__DIR__ . '/BarTrait.php');
+require_once __DIR__ . '/TraitWithSameMethods.php';
+require_once __DIR__ . '/BarTrait.php';
 
-use ZendTest\Code\TestAsset\FooTrait;
 use ZendTest\Code\TestAsset\BarTrait;
+use ZendTest\Code\TestAsset\FooTrait;
 use ZendTest\Code\TestAsset\TraitWithSameMethods;
 
 /**

--- a/test/Scanner/TokenArrayScannerTest.php
+++ b/test/Scanner/TokenArrayScannerTest.php
@@ -10,7 +10,11 @@
 namespace ZendTest\Code\Scanner;
 
 use PHPUnit\Framework\TestCase;
+use Zend\Code\Scanner\ClassScanner;
 use Zend\Code\Scanner\TokenArrayScanner;
+use ZendTest\Code\TestAsset\Baz;
+use ZendTest\Code\TestAsset\FooClass;
+use ZendTest\Code\TestAsset\FooTrait;
 
 class TokenArrayScannerTest extends TestCase
 {
@@ -46,7 +50,7 @@ class TokenArrayScannerTest extends TestCase
         ));
         $classes = $tokenScanner->getClassNames();
         $this->assertInternalType('array', $classes);
-        $this->assertContains('ZendTest\Code\TestAsset\FooClass', $classes);
+        $this->assertContains(FooClass::class, $classes);
     }
 
     /**
@@ -59,7 +63,7 @@ class TokenArrayScannerTest extends TestCase
         ));
         $classes = $tokenScanner->getClassNames();
         $this->assertInternalType('array', $classes);
-        $this->assertContains('ZendTest\Code\TestAsset\FooTrait', $classes);
+        $this->assertContains(FooTrait::class, $classes);
     }
 
     public function testScannerReturnsFunctions()
@@ -77,10 +81,10 @@ class TokenArrayScannerTest extends TestCase
         $tokenScanner = new TokenArrayScanner(token_get_all(
             file_get_contents(__DIR__ . '/../TestAsset/FooClass.php')
         ));
-        $classes = $tokenScanner->getClasses(true);
+        $classes = $tokenScanner->getClasses();
         $this->assertInternalType('array', $classes);
         foreach ($classes as $class) {
-            $this->assertInstanceOf('Zend\Code\Scanner\ClassScanner', $class);
+            $this->assertInstanceOf(ClassScanner::class, $class);
         }
     }
 
@@ -89,10 +93,7 @@ class TokenArrayScannerTest extends TestCase
         $tokenScanner = new TokenArrayScanner(token_get_all(
             file_get_contents(__DIR__ . '/../TestAsset/MultipleNamespaces.php')
         ));
-        $this->assertEquals(
-            'ZendTest\Code\TestAsset\Baz',
-            $tokenScanner->getClass('ZendTest\Code\TestAsset\Baz')->getName()
-        );
+        $this->assertEquals(Baz::class, $tokenScanner->getClass(Baz::class)->getName());
         $this->assertEquals('Foo', $tokenScanner->getClass('Foo')->getName());
     }
 }

--- a/test/Scanner/TokenArrayScannerTest.php
+++ b/test/Scanner/TokenArrayScannerTest.php
@@ -9,8 +9,8 @@
 
 namespace ZendTest\Code\Scanner;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Code\Scanner\TokenArrayScanner;
-use PHPUnit_Framework_TestCase as TestCase;
 
 class TokenArrayScannerTest extends TestCase
 {

--- a/test/TestAsset/TestClassWithTraitAliases.php
+++ b/test/TestAsset/TestClassWithTraitAliases.php
@@ -9,12 +9,8 @@
 
 namespace ZendTest\Code\TestAsset;
 
-require_once(__DIR__ . '/TraitWithSameMethods.php');
-require_once(__DIR__ . '/BarTrait.php');
-
-use ZendTest\Code\TestAsset\FooTrait;
-use ZendTest\Code\TestAsset\BarTrait;
-use ZendTest\Code\TestAsset\TraitWithSameMethods;
+require_once __DIR__ . '/TraitWithSameMethods.php';
+require_once __DIR__ . '/BarTrait.php';
 
 class TestClassWithTraitAliases
 {

--- a/test/TestAsset/TraitWithSameMethods.php
+++ b/test/TestAsset/TraitWithSameMethods.php
@@ -13,11 +13,11 @@ trait TraitWithSameMethods
 {
     public function bar()
     {
-        echo "bar";        
+        echo 'bar';
     }
 
     public function foo()
     {
-        echo "foo";
+        echo 'foo';
     }
 }


### PR DESCRIPTION
- dropped PHP 5.6 and 7.0 support
- updated travis configuration to run on PHP 7.2 (nightly)
- bumped requirements to PHP 7.1
- updated PHPUnit to 6.2.2
- `::class` notation in tests
- removed PHP5.6/7.0 residues