### PR TITLE
Fixes in tests - changed order of params

### DIFF
--- a/test/Generator/ClassGeneratorTest.php
+++ b/test/Generator/ClassGeneratorTest.php
@@ -38,7 +38,7 @@ class ClassGeneratorTest extends TestCase
     {
         $classGenerator = new ClassGenerator();
         $classGenerator->setName('TestClass');
-        self::assertEquals($classGenerator->getName(), 'TestClass');
+        self::assertEquals('TestClass', $classGenerator->getName());
     }
 
     public function testClassDocBlockAccessors()
@@ -61,7 +61,7 @@ class ClassGeneratorTest extends TestCase
     {
         $classGenerator = new ClassGenerator();
         $classGenerator->setExtendedClass('ExtendedClass');
-        self::assertEquals($classGenerator->getExtendedClass(), 'ExtendedClass');
+        self::assertEquals('ExtendedClass', $classGenerator->getExtendedClass());
     }
 
     public function testHasExtendedClass()
@@ -86,7 +86,7 @@ class ClassGeneratorTest extends TestCase
     {
         $classGenerator = new ClassGenerator();
         $classGenerator->setImplementedInterfaces(['Class1', 'Class2']);
-        self::assertEquals($classGenerator->getImplementedInterfaces(), ['Class1', 'Class2']);
+        self::assertEquals(['Class1', 'Class2'], $classGenerator->getImplementedInterfaces());
     }
 
     public function testHasImplementedInterface()
@@ -123,7 +123,7 @@ class ClassGeneratorTest extends TestCase
 
         $property = $classGenerator->getProperty('propTwo');
         self::assertInstanceOf(PropertyGenerator::class, $property);
-        self::assertEquals($property->getName(), 'propTwo');
+        self::assertEquals('propTwo', $property->getName());
 
         // add a new property
         $classGenerator->addProperty('prop3');
@@ -602,7 +602,7 @@ CODE;
 
         self::assertInstanceOf(PropertyGenerator::class, $constant);
         self::assertTrue($constant->isConst());
-        self::assertEquals($constant->getDefaultValue()->getValue(), 'value');
+        self::assertEquals('value', $constant->getDefaultValue()->getValue());
     }
 
     /**
@@ -618,8 +618,8 @@ CODE;
         ]);
 
         self::assertCount(2, $classGenerator->getConstants());
-        self::assertEquals($classGenerator->getConstant('x')->getDefaultValue()->getValue(), 'value1');
-        self::assertEquals($classGenerator->getConstant('y')->getDefaultValue()->getValue(), 'value2');
+        self::assertEquals('value1', $classGenerator->getConstant('x')->getDefaultValue()->getValue());
+        self::assertEquals('value2', $classGenerator->getConstant('y')->getDefaultValue()->getValue());
     }
 
     /**
@@ -635,8 +635,8 @@ CODE;
         ]);
 
         self::assertCount(2, $classGenerator->getConstants());
-        self::assertEquals($classGenerator->getConstant('x')->getDefaultValue()->getValue(), 'value1');
-        self::assertEquals($classGenerator->getConstant('y')->getDefaultValue()->getValue(), 'value2');
+        self::assertEquals('value1', $classGenerator->getConstant('x')->getDefaultValue()->getValue());
+        self::assertEquals('value2', $classGenerator->getConstant('y')->getDefaultValue()->getValue());
     }
 
     /**
@@ -743,7 +743,7 @@ CODE;
 
         $classGenerator->addProperty('x', 'value1', PropertyGenerator::FLAG_CONSTANT);
 
-        self::assertEquals($classGenerator->getConstant('x')->getDefaultValue()->getValue(), 'value1');
+        self::assertEquals('value1', $classGenerator->getConstant('x')->getDefaultValue()->getValue());
     }
 
     /**
@@ -760,8 +760,8 @@ CODE;
         $classGenerator->addProperties($constants);
 
         self::assertCount(2, $classGenerator->getConstants());
-        self::assertEquals($classGenerator->getConstant('x')->getDefaultValue()->getValue(), 'value1');
-        self::assertEquals($classGenerator->getConstant('y')->getDefaultValue()->getValue(), 'value2');
+        self::assertEquals('value1', $classGenerator->getConstant('x')->getDefaultValue()->getValue());
+        self::assertEquals('value2', $classGenerator->getConstant('y')->getDefaultValue()->getValue());
     }
 
     /**
@@ -773,7 +773,7 @@ CODE;
         $classGenerator = ClassGenerator::fromReflection($reflector);
         $constant       = $classGenerator->getConstant('FOO');
 
-        self::assertEquals($constant->getDefaultValue()->getValue(), 'foo');
+        self::assertEquals('foo', $constant->getDefaultValue()->getValue());
     }
 
     /**
@@ -897,8 +897,8 @@ CODE;
 
         $aliases = $classGenerator->getTraitAliases();
         self::assertArrayHasKey('myTrait::method', $aliases);
-        self::assertEquals($aliases['myTrait::method']['alias'], 'useMe');
-        self::assertEquals($aliases['myTrait::method']['visibility'], ReflectionMethod::IS_PRIVATE);
+        self::assertEquals('useMe', $aliases['myTrait::method']['alias']);
+        self::assertEquals(ReflectionMethod::IS_PRIVATE, $aliases['myTrait::method']['visibility']);
     }
 
     public function testCanAddTraitAliasWithArray()
@@ -913,8 +913,8 @@ CODE;
 
         $aliases = $classGenerator->getTraitAliases();
         self::assertArrayHasKey('myTrait::method', $aliases);
-        self::assertEquals($aliases['myTrait::method']['alias'], 'useMe');
-        self::assertEquals($aliases['myTrait::method']['visibility'], ReflectionMethod::IS_PRIVATE);
+        self::assertEquals('useMe', $aliases['myTrait::method']['alias']);
+        self::assertEquals(ReflectionMethod::IS_PRIVATE, $aliases['myTrait::method']['visibility']);
     }
 
     public function testAddTraitAliasExceptionInvalidMethodFormat()
@@ -984,8 +984,8 @@ CODE;
 
         $overrides = $classGenerator->getTraitOverrides();
         self::assertCount(1, $overrides);
-        self::assertEquals(key($overrides), 'myTrait::foo');
-        self::assertEquals($overrides['myTrait::foo'][0], 'hisTrait');
+        self::assertEquals('myTrait::foo', key($overrides));
+        self::assertEquals('hisTrait', $overrides['myTrait::foo'][0]);
     }
 
     public function testCanAddMultipleTraitOverrides()
@@ -996,7 +996,7 @@ CODE;
 
         $overrides = $classGenerator->getTraitOverrides();
         self::assertCount(2, $overrides['myTrait::foo']);
-        self::assertEquals($overrides['myTrait::foo'][1], 'thatTrait');
+        self::assertEquals('thatTrait', $overrides['myTrait::foo'][1]);
     }
 
     public function testAddTraitOverrideExceptionInvalidMethodFormat()
@@ -1067,7 +1067,7 @@ CODE;
         $overrides = $classGenerator->getTraitOverrides();
 
         self::assertCount(1, $overrides['myTrait::foo']);
-        self::assertEquals($overrides['myTrait::foo'][1], 'thatTrait');
+        self::assertEquals('thatTrait', $overrides['myTrait::foo'][1]);
     }
 
     public function testCanRemoveAllTraitOverrides()

--- a/test/Generator/TraitGeneratorTest.php
+++ b/test/Generator/TraitGeneratorTest.php
@@ -38,7 +38,7 @@ class TraitGeneratorTest extends TestCase
     {
         $classGenerator = new TraitGenerator();
         $classGenerator->setName('TestClass');
-        self::assertEquals($classGenerator->getName(), 'TestClass');
+        self::assertEquals('TestClass', $classGenerator->getName());
     }
 
     public function testClassDocBlockAccessors()
@@ -58,7 +58,7 @@ class TraitGeneratorTest extends TestCase
     {
         $classGenerator = new TraitGenerator();
         $classGenerator->setExtendedClass('ExtendedClass');
-        self::assertEquals($classGenerator->getExtendedClass(), null);
+        self::assertNull($classGenerator->getExtendedClass());
     }
 
     public function testImplementedInterfacesAccessors()
@@ -82,7 +82,7 @@ class TraitGeneratorTest extends TestCase
 
         $property = $classGenerator->getProperty('propTwo');
         self::assertInstanceOf(PropertyGenerator::class, $property);
-        self::assertEquals($property->getName(), 'propTwo');
+        self::assertEquals('propTwo', $property->getName());
 
         // add a new property
         $classGenerator->addProperty('prop3');
@@ -122,7 +122,7 @@ class TraitGeneratorTest extends TestCase
 
         $method = $classGenerator->getMethod('methodOne');
         self::assertInstanceOf(MethodGenerator::class, $method);
-        self::assertEquals($method->getName(), 'methodOne');
+        self::assertEquals('methodOne', $method->getName());
 
         // add a new property
         $classGenerator->addMethod('methodThree');

--- a/test/Reflection/ReflectionDocBlockTagTest.php
+++ b/test/Reflection/ReflectionDocBlockTagTest.php
@@ -33,7 +33,7 @@ class ReflectionDocBlockTagTest extends TestCase
         $classReflection = new Reflection\ClassReflection(TestAsset\TestSampleClass6::class);
 
         $tag = $classReflection->getMethod('doSomething')->getDocBlock()->getTag('emptyTag');
-        self::assertEquals($tag->getName(), 'emptyTag', 'Factory First Match Failed');
+        self::assertEquals('emptyTag', $tag->getName(), 'Factory First Match Failed');
     }
 
     public function testTagShouldAllowMultipleWhitespacesBeforeDescription()
@@ -63,7 +63,7 @@ class ReflectionDocBlockTagTest extends TestCase
 
         $paramTag = $classReflection->getMethod('doSomething')->getDocBlock()->getTag('param');
 
-        self::assertEquals($paramTag->getType(), 'int');
+        self::assertEquals('int', $paramTag->getType());
     }
 
     public function testVariableName()
@@ -71,7 +71,7 @@ class ReflectionDocBlockTagTest extends TestCase
         $classReflection = new Reflection\ClassReflection(TestAsset\TestSampleClass5::class);
 
         $paramTag = $classReflection->getMethod('doSomething')->getDocBlock()->getTag('param');
-        self::assertEquals($paramTag->getVariableName(), '$one');
+        self::assertEquals('$one', $paramTag->getVariableName());
     }
 
     public function testAllowsMultipleSpacesInDocBlockTagLine()
@@ -80,10 +80,9 @@ class ReflectionDocBlockTagTest extends TestCase
 
         $paramTag = $classReflection->getMethod('doSomething')->getDocBlock()->getTag('param');
 
-
-        self::assertEquals($paramTag->getType(), 'int', 'Second Match Failed');
-        self::assertEquals($paramTag->getVariableName(), '$var', 'Third Match Failed');
-        self::assertEquals($paramTag->getDescription(), 'Description of $var', 'Final Match Failed');
+        self::assertEquals('int', $paramTag->getType(), 'Second Match Failed');
+        self::assertEquals('$var', $paramTag->getVariableName(), 'Third Match Failed');
+        self::assertEquals('Description of $var', $paramTag->getDescription(), 'Final Match Failed');
     }
 
 
@@ -106,7 +105,7 @@ class ReflectionDocBlockTagTest extends TestCase
         $classReflection = new Reflection\ClassReflection(TestAsset\TestSampleClass5::class);
 
         $paramTag = $classReflection->getMethod('doSomething')->getDocBlock()->getTag('return');
-        self::assertEquals($paramTag->getType(), 'mixed');
+        self::assertEquals('mixed', $paramTag->getType());
     }
 
     public function testAllowsMultipleSpacesInDocBlockTagLine2()
@@ -115,8 +114,8 @@ class ReflectionDocBlockTagTest extends TestCase
 
         $paramTag = $classReflection->getMethod('doSomething')->getDocBlock()->getTag('return');
 
-        self::assertEquals($paramTag->getType(), 'string', 'Second Match Failed');
-        self::assertEquals($paramTag->getDescription(), 'Description of return value', 'Final Match Failed');
+        self::assertEquals('string', $paramTag->getType(), 'Second Match Failed');
+        self::assertEquals('Description of return value', $paramTag->getDescription(), 'Final Match Failed');
     }
 
 


### PR DESCRIPTION
In assertions we should have as the first param "expected value" and as the second "actual".
In some places we have it incorrectly.