### PR TITLE
Remove IRC notifications in travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,6 @@ matrix:
     - php: nightly
 
 notifications:
-  irc: "irc.freenode.org#zftalk.dev"
   email: false
 
 before_install:


### PR DESCRIPTION
This channel is no longer supported.