### PR TITLE
Add MethodGenerator::copyMethodSignature without body and phpdoc

### DIFF
--- a/src/Generator/MethodGenerator.php
+++ b/src/Generator/MethodGenerator.php
@@ -58,17 +58,32 @@ class MethodGenerator extends AbstractMemberGenerator
      */
     public static function fromReflection(MethodReflection $reflectionMethod)
     {
-        $method         = new static();
-        $declaringClass = $reflectionMethod->getDeclaringClass();
+        $method = static::copyMethodSignature($reflectionMethod);
 
         $method->setSourceContent($reflectionMethod->getContents(false));
         $method->setSourceDirty(false);
-        $method->setReturnType(self::extractReturnTypeFromMethodReflection($reflectionMethod));
 
         if ($reflectionMethod->getDocComment() != '') {
             $method->setDocBlock(DocBlockGenerator::fromReflection($reflectionMethod->getDocBlock()));
         }
 
+        $method->setBody(static::clearBodyIndention($reflectionMethod->getBody()));
+
+        return $method;
+    }
+
+    /**
+     * Returns a MethodGenerator based on a MethodReflection with only the signature copied.
+     *
+     * This is similar to fromReflection() but without the method body and phpdoc as this is quite heavy to copy.
+     * It's for example useful when creating proxies where you normally change the method body anyway.
+     */
+    public static function copyMethodSignature(MethodReflection $reflectionMethod): MethodGenerator
+    {
+        $method         = new static();
+        $declaringClass = $reflectionMethod->getDeclaringClass();
+
+        $method->setReturnType(self::extractReturnTypeFromMethodReflection($reflectionMethod));
         $method->setFinal($reflectionMethod->isFinal());
 
         if ($reflectionMethod->isPrivate()) {
@@ -87,8 +102,6 @@ class MethodGenerator extends AbstractMemberGenerator
         foreach ($reflectionMethod->getParameters() as $reflectionParameter) {
             $method->setParameter(ParameterGenerator::fromReflection($reflectionParameter));
         }
-
-        $method->setBody(static::clearBodyIndention($reflectionMethod->getBody()));
 
         return $method;
     }

--- a/test/Generator/ClassGeneratorTest.php
+++ b/test/Generator/ClassGeneratorTest.php
@@ -821,7 +821,7 @@ class TestSampleSingleClass
      *
      * @return bool
      */
-    protected function withParamsAndReturnType($mixed, array $array, callable $callable, ?string $string = null, iterable $iterable = array(), ?int $int = 0) : bool
+    protected function withParamsAndReturnType($mixed, array $array, ?callable $callable = null, ?int $int = 0) : bool
     {
         /* test test */
         return true;

--- a/test/Generator/ClassGeneratorTest.php
+++ b/test/Generator/ClassGeneratorTest.php
@@ -816,6 +816,17 @@ class TestSampleSingleClass
         /* test test */
     }
 
+    /**
+     * Enter description here...
+     *
+     * @return bool
+     */
+    protected function withParamsAndReturnType($mixed, array $array, callable $callable, ?string $string = null, iterable $iterable = array(), ?int $int = 0) : bool
+    {
+        /* test test */
+        return true;
+    }
+
 
 }
 

--- a/test/Generator/FileGeneratorTest.php
+++ b/test/Generator/FileGeneratorTest.php
@@ -113,7 +113,7 @@ EOS;
 
         $codeGenFileFromDisk->getClass()->addMethod('foobar');
 
-        $expectedOutput = <<<EOS
+        $expectedOutput = <<<'EOS'
 <?php
 /**
  * File header here
@@ -138,6 +138,17 @@ class TestSampleSingleClass
     public function someMethod()
     {
         /* test test */
+    }
+
+    /**
+     * Enter description here...
+     *
+     * @return bool
+     */
+    protected function withParamsAndReturnType($mixed, array $array, callable $callable, ?string $string = null, iterable $iterable = array(), ?int $int = 0) : bool
+    {
+        /* test test */
+        return true;
     }
 
     public function foobar()

--- a/test/Generator/FileGeneratorTest.php
+++ b/test/Generator/FileGeneratorTest.php
@@ -145,7 +145,7 @@ class TestSampleSingleClass
      *
      * @return bool
      */
-    protected function withParamsAndReturnType($mixed, array $array, callable $callable, ?string $string = null, iterable $iterable = array(), ?int $int = 0) : bool
+    protected function withParamsAndReturnType($mixed, array $array, ?callable $callable = null, ?int $int = 0) : bool
     {
         /* test test */
         return true;

--- a/test/Generator/MethodGeneratorTest.php
+++ b/test/Generator/MethodGeneratorTest.php
@@ -100,7 +100,7 @@ class MethodGeneratorTest extends TestCase
 
         $methodGenerator = MethodGenerator::copyMethodSignature($ref);
         $target = <<<'EOS'
-    protected function withParamsAndReturnType($mixed, array $array, callable $callable, ?string $string = null, iterable $iterable = array(), ?int $int = 0) : bool
+    protected function withParamsAndReturnType($mixed, array $array, ?callable $callable = null, ?int $int = 0) : bool
     {
     }
 

--- a/test/Generator/MethodGeneratorTest.php
+++ b/test/Generator/MethodGeneratorTest.php
@@ -94,6 +94,20 @@ class MethodGeneratorTest extends TestCase
         self::assertSame($docblockGenerator, $method->getDocBlock());
     }
 
+    public function testCopyMethodSignature()
+    {
+        $ref = new MethodReflection(TestAsset\TestSampleSingleClass::class, 'withParamsAndReturnType');
+
+        $methodGenerator = MethodGenerator::copyMethodSignature($ref);
+        $target = <<<'EOS'
+    protected function withParamsAndReturnType($mixed, array $array, callable $callable, ?string $string = null, iterable $iterable = array(), ?int $int = 0) : bool
+    {
+    }
+
+EOS;
+        self::assertEquals($target, (string) $methodGenerator);
+    }
+
     public function testMethodFromReflection()
     {
         $ref = new MethodReflection(TestAsset\TestSampleSingleClass::class, 'someMethod');

--- a/test/Generator/TestAsset/TestSampleSingleClass.php
+++ b/test/Generator/TestAsset/TestSampleSingleClass.php
@@ -23,4 +23,21 @@ class TestSampleSingleClass
         /* test test */
     }
 
+    /**
+     * Enter description here...
+     *
+     * @return bool
+     */
+    protected function withParamsAndReturnType(
+        $mixed,
+        array $array,
+        callable $callable,
+        string $string = null,
+        iterable $iterable = [],
+        ?int $int = 0
+    ): bool {
+        /* test test */
+        return true;
+    }
+
 }

--- a/test/Generator/TestAsset/TestSampleSingleClass.php
+++ b/test/Generator/TestAsset/TestSampleSingleClass.php
@@ -31,9 +31,7 @@ class TestSampleSingleClass
     protected function withParamsAndReturnType(
         $mixed,
         array $array,
-        callable $callable,
-        string $string = null,
-        iterable $iterable = [],
+        callable $callable = null,
         ?int $int = 0
     ): bool {
         /* test test */


### PR DESCRIPTION
Adds a `Zend\Code\Generator\MethodGenerator::copyMethodSignature` method that is similar to `fromReflection()` but without the copying the method body and phpdoc as this is quite heavy to parse (it requires file IO, regexes, tokenization of code).
It's for example useful when creating proxies where you normally change the method body afterwards anyway. See https://github.com/Ocramius/ProxyManager/pull/393 where it increases performance.