### PR TITLE
Corrected the exception class used and removed unnecessary strtolower in MethodScanner::setVisibility

### DIFF
--- a/src/Scanner/MethodScanner.php
+++ b/src/Scanner/MethodScanner.php
@@ -303,7 +303,7 @@ class MethodScanner implements ScannerInterface
                 break;
 
             default:
-                throw new Exception('Invalid visibility argument passed to setVisibility.');
+                throw new Exception\InvalidArgumentException('Invalid visibility argument passed to setVisibility.');
         }
 
         return $this;

--- a/src/Scanner/MethodScanner.php
+++ b/src/Scanner/MethodScanner.php
@@ -279,11 +279,11 @@ class MethodScanner implements ScannerInterface
      *
      * @param int $visibility   T_PUBLIC | T_PRIVATE | T_PROTECTED
      * @return self
-     * @throws \Zend\Code\Exception
+     * @throws \Zend\Code\Exception\InvalidArgumentException
      */
     public function setVisibility($visibility)
     {
-        switch (strtolower($visibility)) {
+        switch ($visibility) {
             case T_PUBLIC:
                 $this->isPublic = true;
                 $this->isPrivate = false;

--- a/test/Scanner/MethodScannerTest.php
+++ b/test/Scanner/MethodScannerTest.php
@@ -12,6 +12,7 @@ namespace ZendTest\Code\Scanner;
 use PHPUnit\Framework\TestCase;
 use Zend\Code\Scanner\FileScanner;
 use Zend\Code\Scanner\ParameterScanner;
+use Zend\Code\Scanner\MethodScanner;
 use ZendTest\Code\TestAsset\AbstractClass;
 use ZendTest\Code\TestAsset\BarClass;
 use ZendTest\Code\TestAsset\FooClass;
@@ -109,5 +110,28 @@ class MethodScannerTest extends TestCase
         $method = $class->getMethod('helloWorld');
 
         self::assertTrue($method->isAbstract());
+    }
+
+    /**
+     * @expectedException \Zend\Code\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Invalid visibility argument passed to setVisibility.
+     */
+
+    public function testMethodScannerSetVisibilityThrowsInvalidArgumentException()
+    {
+        $methodScanner = new MethodScanner([]);
+
+        $invalidArgument = 42;
+        self::assertTrue(!in_array($invalidArgument, [T_PUBLIC, T_PROTECTED, T_PRIVATE]));
+        $methodScanner->setVisibility(42);
+    }
+
+    public function testMethodScannerSetVisibilityAcceptsIntegerTokens()
+    {
+        $methodScanner = new MethodScanner([]);
+
+        self::assertTrue($methodScanner->setVisibility(T_PUBLIC) === $methodScanner);
+        self::assertTrue($methodScanner->setVisibility(T_PROTECTED) === $methodScanner);
+        self::assertTrue($methodScanner->setVisibility(T_PRIVATE) === $methodScanner);
     }
 }

--- a/test/Scanner/MethodScannerTest.php
+++ b/test/Scanner/MethodScannerTest.php
@@ -117,8 +117,7 @@ class MethodScannerTest extends TestCase
         $methodScanner = new MethodScanner([]);
 
         // make sure test argument is invalid
-        $min = min(T_PUBLIC, T_PROTECTED, T_PRIVATE);
-        $invalidArgument = $min > 42 ? 42 : 43;
+        $invalidArgument = max(T_PUBLIC, T_PROTECTED, T_PRIVATE) + 1;
 
         $this->expectException('\Zend\Code\Exception\InvalidArgumentException');
         $methodScanner->setVisibility($invalidArgument);

--- a/test/Scanner/MethodScannerTest.php
+++ b/test/Scanner/MethodScannerTest.php
@@ -112,26 +112,24 @@ class MethodScannerTest extends TestCase
         self::assertTrue($method->isAbstract());
     }
 
-    /**
-     * @expectedException \Zend\Code\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Invalid visibility argument passed to setVisibility.
-     */
-
     public function testMethodScannerSetVisibilityThrowsInvalidArgumentException()
     {
         $methodScanner = new MethodScanner([]);
 
-        $invalidArgument = 42;
-        self::assertTrue(! in_array($invalidArgument, [T_PUBLIC, T_PROTECTED, T_PRIVATE]));
-        $methodScanner->setVisibility(42);
+        // make sure test argument is invalid
+        $min = min(T_PUBLIC, T_PROTECTED, T_PRIVATE);
+        $invalidArgument = $min > 42 ? 42 : 43;
+
+        $this->expectException('\Zend\Code\Exception\InvalidArgumentException');
+        $methodScanner->setVisibility($invalidArgument);
     }
 
     public function testMethodScannerSetVisibilityAcceptsIntegerTokens()
     {
         $methodScanner = new MethodScanner([]);
 
-        self::assertTrue($methodScanner->setVisibility(T_PUBLIC) === $methodScanner);
-        self::assertTrue($methodScanner->setVisibility(T_PROTECTED) === $methodScanner);
-        self::assertTrue($methodScanner->setVisibility(T_PRIVATE) === $methodScanner);
+        $this->assertSame($methodScanner->setVisibility(T_PUBLIC), $methodScanner);
+        $this->assertSame($methodScanner->setVisibility(T_PROTECTED), $methodScanner);
+        $this->assertSame($methodScanner->setVisibility(T_PRIVATE), $methodScanner);
     }
 }

--- a/test/Scanner/MethodScannerTest.php
+++ b/test/Scanner/MethodScannerTest.php
@@ -122,7 +122,7 @@ class MethodScannerTest extends TestCase
         $methodScanner = new MethodScanner([]);
 
         $invalidArgument = 42;
-        self::assertTrue(!in_array($invalidArgument, [T_PUBLIC, T_PROTECTED, T_PRIVATE]));
+        self::assertTrue(! in_array($invalidArgument, [T_PUBLIC, T_PROTECTED, T_PRIVATE]));
         $methodScanner->setVisibility(42);
     }
 


### PR DESCRIPTION
Exception - which is used as exception class within setVisibility - is not a class but a (sub)namespace. InvalidArgumentException likely is the intended exception class here.

This is my first submission. Wanted to get my feet wet with the submission workflow. :)