### PR TITLE
Fixed class generator ignoring use aliases for extended class

### DIFF
--- a/src/Generator/ClassGenerator.php
+++ b/src/Generator/ClassGenerator.php
@@ -1145,6 +1145,20 @@ class ClassGenerator extends AbstractGenerator implements TraitUsageInterface
         $classNamespace = implode('\\', $parts);
         $currentNamespace = (string) $this->getNamespaceName();
 
+        if ($this->hasUseAlias($fqnClassName)) {
+            return $this->traitUsageGenerator->getUseAlias($fqnClassName);
+        }
+        if ($this->hasUseAlias($classNamespace)) {
+            $namespaceAlias = $this->traitUsageGenerator->getUseAlias($classNamespace);
+
+            return $namespaceAlias . '\\' . $className;
+        }
+        if ($this->traitUsageGenerator->isUseAlias($fqnClassName)) {
+            return $fqnClassName;
+        }
+        if ($this->traitUsageGenerator->isUseAlias($classNamespace)) {
+            return $fqnClassName;
+        }
         if ($classNamespace === $currentNamespace || in_array($fqnClassName, $this->getUses())) {
             return $className;
         }

--- a/src/Generator/TraitUsageGenerator.php
+++ b/src/Generator/TraitUsageGenerator.php
@@ -113,6 +113,40 @@ class TraitUsageGenerator extends AbstractGenerator implements TraitUsageInterfa
     }
 
     /**
+     * Returns the alias of the provided FQCN
+     *
+     * @param string $use
+     * @return string|null
+     */
+    public function getUseAlias(string $use): ?string
+    {
+        foreach ($this->uses as $key => $value) {
+            $parts = explode(' as ', $key);
+            if ($parts[0] === $use && count($parts) == 2) {
+                return $parts[1];
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Returns true if the alias is defined in the use list
+     *
+     * @param string $alias
+     * @return bool
+     */
+    public function isUseAlias(string $alias): bool
+    {
+        foreach ($this->uses as $key => $value) {
+            $parts = explode(' as ', $key);
+            if (count($parts) === 2 && $parts[1] === $alias) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * @param string $use
      * @return TraitUsageGenerator
      */

--- a/test/Generator/ClassGeneratorTest.php
+++ b/test/Generator/ClassGeneratorTest.php
@@ -1228,6 +1228,50 @@ EOS;
         self::assertContains('class ClassName extends DateTime', $classGenerator->generate());
     }
 
+    public function testCorrectlyExtendsProvidedAliasIfUseAliasExists()
+    {
+        $classGenerator = new ClassGenerator();
+        $classGenerator->setName('ClassName');
+        $classGenerator->setNamespaceName('SomeNamespace');
+        $classGenerator->addUse('Foo\\Bar', 'BarAlias');
+        $classGenerator->setExtendedClass('BarAlias');
+        $generated = $classGenerator->generate();
+        self::assertContains('class ClassName extends BarAlias', $generated);
+    }
+
+    public function testCorrectlyExtendsProvidedNamespaceAliasIfUseAliasExistsForNamespace()
+    {
+        $classGenerator = new ClassGenerator();
+        $classGenerator->setName('ClassName');
+        $classGenerator->setNamespaceName('SomeNamespace');
+        $classGenerator->addUse('Foo\\Bar', 'BarAlias');
+        $classGenerator->setExtendedClass('BarAlias\\FooBar');
+        $generated = $classGenerator->generate();
+        self::assertContains('class ClassName extends BarAlias\\FooBar', $generated);
+    }
+
+    public function testCorrectlyExtendsAliasOfProvidedFQCNIfUseAliasExists()
+    {
+        $classGenerator = new ClassGenerator();
+        $classGenerator->setName('ClassName');
+        $classGenerator->setNamespaceName('SomeNamespace');
+        $classGenerator->addUse('Foo\\Bar', 'BarAlias');
+        $classGenerator->setExtendedClass('Foo\\Bar');
+        $generated = $classGenerator->generate();
+        self::assertContains('class ClassName extends BarAlias', $generated);
+    }
+
+    public function testCorrectlyExtendsWithNamespaceAliasOfProvidedFQCNIfUseAliasExistsForNamespace()
+    {
+        $classGenerator = new ClassGenerator();
+        $classGenerator->setName('ClassName');
+        $classGenerator->setNamespaceName('SomeNamespace');
+        $classGenerator->addUse('Foo\\Bar', 'BarAlias');
+        $classGenerator->setExtendedClass('Foo\\Bar\\FooBar');
+        $generated = $classGenerator->generate();
+        self::assertContains('class ClassName extends BarAlias\\FooBar', $generated);
+    }
+
     public function testCorrectImplementNames()
     {
         $classGenerator = new ClassGenerator();


### PR DESCRIPTION
This PR contains a fix for the class generator when using a _use_ alias for the extended
class.

### Bug explanation

Before this patch, the class generator would ignore all use aliases. This resulted
in an incorrect _extends_ class. For example:

```php
$classGenerator = new ClassGenerator();
$classGenerator->setName('ClassName');
$classGenerator->setNamespaceName('SomeNamespace');
$classGenerator->addUse('Foo\\Bar', 'BarAlias');
$classGenerator->setExtendedClass('BarAlias');
echo $classGenerator->generate();
```
would result in:
```php
namespace SomeNamespace;

use Foo\Bar as BarAlias;

class ClassName extends \BarAlias {}
```

When using an FQCN for the extended class, it would ignore the use statement:

```php
$classGenerator = new ClassGenerator();
$classGenerator->setName('ClassName');
$classGenerator->setNamespaceName('SomeNamespace');
$classGenerator->addUse('Foo\\Bar', 'BarAlias');
$classGenerator->setExtendedClass('Foo\\Bar');
echo $classGenerator->generate();
```
would result in:
```php
namespace SomeNamespace;

use Foo\Bar as BarAlias;

class ClassName extends \Foo\Bar {}
```




### Fix explanation
This PR fixes the ClassGenerator by checking whether the extended class matches
one of the use statements.
It supports the following varieties:

#### Using an alias as the extended class
```php
$classGenerator->setName('ClassName');
$classGenerator->setNamespaceName('SomeNamespace');
$classGenerator->addUse('Foo\\Bar', 'BarAlias');
$classGenerator->setExtendedClass('BarAlias');
```
will result in:
```php
namespace SomeNamespace;

use Foo\Bar as BarAlias;

class ClassName extends BarAlias {}
```

#### Using an alias of the extended class namespace
```php
$classGenerator->setName('ClassName');
$classGenerator->setNamespaceName('SomeNamespace');
$classGenerator->addUse('Foo\\Bar', 'BarAlias');
$classGenerator->setExtendedClass('BarAlias\\FooBar');
```
will result in:
```php
namespace SomeNamespace;

use Foo\Bar as BarAlias;

class ClassName extends BarAlias\FooBar {}
```

#### Using an FQCN as the extended class
The class generator will replace the extended class with its alias, if an exact use
statement match is defined.

```php
$classGenerator->setName('ClassName');
$classGenerator->setNamespaceName('SomeNamespace');
$classGenerator->addUse('Foo\\Bar', 'BarAlias');
$classGenerator->setExtendedClass('Foo\\Bar');
```
will result in:
```php
namespace SomeNamespace;

use Foo\Bar as BarAlias;

class ClassName extends BarAlias {}
```

The class generator will replace the _namespace_ of the extended class with its alias,
if an exact use statement match is defined.

```php
$classGenerator->setName('ClassName');
$classGenerator->setNamespaceName('SomeNamespace');
$classGenerator->addUse('Foo\\Bar', 'BarAlias');
$classGenerator->setExtendedClass('Foo\\Bar\\FooBar');
```
will result in:
```php
namespace SomeNamespace;

use Foo\Bar as BarAlias;

class ClassName extends BarAlias\FooBar {}
```
