### PR TITLE
Fixed thrown exception class in MethodScanner#setVisibility()

### DIFF
--- a/src/Scanner/MethodScanner.php
+++ b/src/Scanner/MethodScanner.php
@@ -279,7 +279,7 @@ class MethodScanner implements ScannerInterface
      *
      * @param int $visibility   T_PUBLIC | T_PRIVATE | T_PROTECTED
      * @return self
-     * @throws \Zend\Code\Exception
+     * @throws \Zend\Code\Exception\InvalidArgumentException
      */
     public function setVisibility($visibility)
     {
@@ -303,7 +303,7 @@ class MethodScanner implements ScannerInterface
                 break;
 
             default:
-                throw new Exception('Invalid visibility argument passed to setVisibility.');
+                throw new Exception\InvalidArgumentException('Invalid visibility argument passed to setVisibility.');
         }
 
         return $this;

--- a/test/Scanner/MethodScannerTest.php
+++ b/test/Scanner/MethodScannerTest.php
@@ -10,7 +10,9 @@
 namespace ZendTest\Code\Scanner;
 
 use PHPUnit\Framework\TestCase;
+use Zend\Code\Exception\InvalidArgumentException;
 use Zend\Code\Scanner\FileScanner;
+use Zend\Code\Scanner\MethodScanner;
 use Zend\Code\Scanner\ParameterScanner;
 use ZendTest\Code\TestAsset\AbstractClass;
 use ZendTest\Code\TestAsset\BarClass;
@@ -109,5 +111,14 @@ class MethodScannerTest extends TestCase
         $method = $class->getMethod('helloWorld');
 
         self::assertTrue($method->isAbstract());
+    }
+
+    public function testMethodScannerThrowsExceptionWhenSettingInvalidVisibility()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid visibility argument passed to setVisibility.');
+
+        $methodScanner = new MethodScanner([]);
+        $methodScanner->setVisibility(-1);
     }
 }


### PR DESCRIPTION
This PR fixes a bug in `Zend\Code\Scanner\MethodScanner#setVisibility()`, in which the method throws a nonexistent `Zend\Code\Exception` if the provided visibility value is invalid.
It is fixed by replacing the thrown exception with `Zend\Code\Exception\InvalidArgumentException`.