### PR TITLE
Fixed docblock return types for 3.x releases

### DIFF
--- a/src/Generator/ClassGenerator.php
+++ b/src/Generator/ClassGenerator.php
@@ -743,7 +743,7 @@ class ClassGenerator extends AbstractGenerator implements TraitUsageInterface
 
     /**
      * @param string $use
-     * @return self
+     * @return bool
      */
     public function hasUse($use)
     {

--- a/src/Generator/DocBlock/Tag/AbstractTypeableTag.php
+++ b/src/Generator/DocBlock/Tag/AbstractTypeableTag.php
@@ -50,7 +50,7 @@ abstract class AbstractTypeableTag extends AbstractGenerator
 
     /**
      * @param string $description
-     * @return ReturnTag
+     * @return AbstractTypeableTag
      */
     public function setDescription($description)
     {
@@ -71,7 +71,7 @@ abstract class AbstractTypeableTag extends AbstractGenerator
      * e.g. array('int', 'null') or "int|null"
      *
      * @param array|string $types
-     * @return ReturnTag
+     * @return AbstractTypeableTag
      */
     public function setTypes($types)
     {

--- a/src/Generator/DocBlock/Tag/AuthorTag.php
+++ b/src/Generator/DocBlock/Tag/AuthorTag.php
@@ -42,7 +42,7 @@ class AuthorTag extends AbstractGenerator implements TagInterface
 
     /**
      * @param ReflectionTagInterface $reflectionTag
-     * @return ReturnTag
+     * @return AuthorTag
      * @deprecated Deprecated in 2.3. Use TagManager::createTagFromReflection() instead
      */
     public static function fromReflection(ReflectionTagInterface $reflectionTag)

--- a/src/Generator/DocBlock/Tag/ParamTag.php
+++ b/src/Generator/DocBlock/Tag/ParamTag.php
@@ -37,7 +37,7 @@ class ParamTag extends AbstractTypeableTag implements TagInterface
 
     /**
      * @param ReflectionTagInterface $reflectionTag
-     * @return ReturnTag
+     * @return ParamTag
      * @deprecated Deprecated in 2.3. Use TagManager::createTagFromReflection() instead
      */
     public static function fromReflection(ReflectionTagInterface $reflectionTag)
@@ -75,7 +75,7 @@ class ParamTag extends AbstractTypeableTag implements TagInterface
 
     /**
      * @param string $datatype
-     * @return ReturnTag
+     * @return ParamTag
      * @deprecated Deprecated in 2.3. Use setTypes() instead
      */
     public function setDatatype($datatype)

--- a/src/Generator/DocBlockGenerator.php
+++ b/src/Generator/DocBlockGenerator.php
@@ -49,6 +49,9 @@ class DocBlockGenerator extends AbstractGenerator
      */
     protected $wordwrap = true;
 
+    /**
+     * @var TagManager
+     */
     protected static $tagManager;
 
     /**
@@ -107,6 +110,9 @@ class DocBlockGenerator extends AbstractGenerator
         return $docBlock;
     }
 
+    /**
+     * @return TagManager
+     */
     protected static function getTagManager()
     {
         if (! isset(static::$tagManager)) {

--- a/src/Reflection/ClassReflection.php
+++ b/src/Reflection/ClassReflection.php
@@ -50,7 +50,7 @@ class ClassReflection extends ReflectionClass implements ReflectionInterface
     /**
      * Return the classes DocBlock reflection object
      *
-     * @return DocBlockReflection
+     * @return DocBlockReflection|false
      * @throws Exception\ExceptionInterface for missing DocBock or invalid reflection class
      */
     public function getDocBlock()
@@ -70,7 +70,7 @@ class ClassReflection extends ReflectionClass implements ReflectionInterface
 
     /**
      * @param  AnnotationManager $annotationManager
-     * @return AnnotationCollection
+     * @return AnnotationCollection|false
      */
     public function getAnnotations(AnnotationManager $annotationManager)
     {
@@ -188,7 +188,7 @@ class ClassReflection extends ReflectionClass implements ReflectionInterface
     /**
      * Returns an array of reflection classes of traits used by this class.
      *
-     * @return void|array
+     * @return null|array
      */
     public function getTraits()
     {

--- a/src/Reflection/DocBlock/Tag/MethodTag.php
+++ b/src/Reflection/DocBlock/Tag/MethodTag.php
@@ -78,7 +78,7 @@ class MethodTag implements TagInterface, PhpDocTypedTagInterface
     /**
      * Get return value type
      *
-     * @return void|string
+     * @return null|string
      * @deprecated 2.0.4 use getTypes instead
      */
     public function getReturnType()

--- a/src/Reflection/DocBlock/Tag/PropertyTag.php
+++ b/src/Reflection/DocBlock/Tag/PropertyTag.php
@@ -64,7 +64,7 @@ class PropertyTag implements TagInterface, PhpDocTypedTagInterface
     }
 
     /**
-     * @return void|string
+     * @return null|string
      * @deprecated 2.0.4 use getTypes instead
      */
     public function getType()

--- a/src/Reflection/DocBlockReflection.php
+++ b/src/Reflection/DocBlockReflection.php
@@ -91,7 +91,6 @@ class DocBlockReflection implements ReflectionInterface
      * @param  Reflector|string $commentOrReflector
      * @param  null|DocBlockTagManager $tagManager
      * @throws Exception\InvalidArgumentException
-     * @return DocBlockReflection
      */
     public function __construct($commentOrReflector, DocBlockTagManager $tagManager = null)
     {

--- a/src/Reflection/FileReflection.php
+++ b/src/Reflection/FileReflection.php
@@ -158,7 +158,7 @@ class FileReflection implements ReflectionInterface
     }
 
     /**
-     * @return DocBlockReflection
+     * @return DocBlockReflection|false
      */
     public function getDocBlock()
     {
@@ -180,7 +180,7 @@ class FileReflection implements ReflectionInterface
     }
 
     /**
-     * @return void|string
+     * @return null|string
      */
     public function getNamespace()
     {

--- a/src/Reflection/FunctionReflection.php
+++ b/src/Reflection/FunctionReflection.php
@@ -132,7 +132,7 @@ class FunctionReflection extends ReflectionFunction implements ReflectionInterfa
      * Get method prototype
      *
      * @param string $format
-     * @return array
+     * @return array|string
      */
     public function getPrototype($format = FunctionReflection::PROTOTYPE_AS_ARRAY)
     {

--- a/src/Reflection/MethodReflection.php
+++ b/src/Reflection/MethodReflection.php
@@ -64,7 +64,7 @@ class MethodReflection extends PhpReflectionMethod implements ReflectionInterfac
 
     /**
      * @param  AnnotationManager $annotationManager
-     * @return AnnotationScanner
+     * @return AnnotationScanner|false
      */
     public function getAnnotations(AnnotationManager $annotationManager)
     {
@@ -123,7 +123,7 @@ class MethodReflection extends PhpReflectionMethod implements ReflectionInterfac
      * Get method prototype
      *
      * @param string $format
-     * @return array
+     * @return array|string
      */
     public function getPrototype($format = MethodReflection::PROTOTYPE_AS_ARRAY)
     {

--- a/src/Reflection/ParameterReflection.php
+++ b/src/Reflection/ParameterReflection.php
@@ -37,13 +37,13 @@ class ParameterReflection extends ReflectionParameter implements ReflectionInter
     /**
      * Get class reflection object
      *
-     * @return void|ClassReflection
+     * @return null|ClassReflection
      */
     public function getClass()
     {
         $phpReflection = parent::getClass();
         if ($phpReflection === null) {
-            return;
+            return null;
         }
 
         $zendReflection = new ClassReflection($phpReflection->getName());

--- a/src/Reflection/PropertyReflection.php
+++ b/src/Reflection/PropertyReflection.php
@@ -64,7 +64,7 @@ class PropertyReflection extends PhpReflectionProperty implements ReflectionInte
 
     /**
      * @param  AnnotationManager $annotationManager
-     * @return AnnotationScanner
+     * @return AnnotationScanner|false
      */
     public function getAnnotations(AnnotationManager $annotationManager)
     {

--- a/src/Scanner/MethodScanner.php
+++ b/src/Scanner/MethodScanner.php
@@ -189,7 +189,7 @@ class MethodScanner implements ScannerInterface
 
     /**
      * @param  AnnotationManager $annotationManager
-     * @return AnnotationScanner
+     * @return AnnotationScanner|false
      */
     public function getAnnotations(AnnotationManager $annotationManager)
     {

--- a/src/Scanner/PropertyScanner.php
+++ b/src/Scanner/PropertyScanner.php
@@ -211,7 +211,7 @@ class PropertyScanner implements ScannerInterface
 
     /**
      * @param Annotation\AnnotationManager $annotationManager
-     * @return AnnotationScanner
+     * @return AnnotationScanner|false
      */
     public function getAnnotations(Annotation\AnnotationManager $annotationManager)
     {

--- a/src/Scanner/TokenArrayScanner.php
+++ b/src/Scanner/TokenArrayScanner.php
@@ -76,7 +76,7 @@ class TokenArrayScanner implements ScannerInterface
      * @todo Assignment of $this->docComment should probably be done in scan()
      *       and then $this->getDocComment() just retrieves it.
      *
-     * @return string
+     * @return string|null
      */
     public function getDocComment()
     {
@@ -176,7 +176,7 @@ class TokenArrayScanner implements ScannerInterface
      *
      * @param  string|int $name
      * @throws Exception\InvalidArgumentException
-     * @return ClassScanner
+     * @return ClassScanner|false
      */
     public function getClass($name)
     {
@@ -663,7 +663,7 @@ class TokenArrayScanner implements ScannerInterface
 
     /**
      * @param  string $namespace
-     * @return void|array
+     * @return null|array
      * @throws Exception\InvalidArgumentException
      */
     protected function getUsesNoScan($namespace)


### PR DESCRIPTION
This PR contains docblock return type fixes. It might be a good idea to merge this, if 4.0.0 won't be released any time soon.