### PR TITLE
Fixed regex pattern in VarTag doc block reflection class

### DIFF
--- a/src/Reflection/DocBlock/Tag/VarTag.php
+++ b/src/Reflection/DocBlock/Tag/VarTag.php
@@ -41,7 +41,11 @@ class VarTag implements TagInterface, PhpDocTypedTagInterface
     {
         $match = [];
 
-        if (! preg_match('#^(.+)?(\$[\S]+)\s*(.*)$#m', $tagDocblockLine, $match)) {
+        if (! preg_match(
+            '#^([^\$]\S+)?\s*(\$[\S]+)?\s*(.*)$#m',
+            $tagDocblockLine,
+            $match
+        )) {
             return;
         }
 

--- a/test/Reflection/DocBlock/Tag/VarTagTest.php
+++ b/test/Reflection/DocBlock/Tag/VarTagTest.php
@@ -18,37 +18,86 @@ use Zend\Code\Reflection\DocBlock\Tag\VarTag;
  */
 class VarTagTest extends TestCase
 {
-    public function testParseName()
-    {
+    /**
+     * @dataProvider varTagProvider
+     */
+    public function testParse(
+        string $line,
+        array $expectedTypes,
+        ?string $expectedVariableName,
+        ?string $expectedDescription
+    ) {
         $tag = new VarTag();
-        $tag->initialize('$test');
-        $this->assertEquals('var', $tag->getName());
-        $this->assertEquals('$test', $tag->getVariableName());
-        $this->assertNull($tag->getDescription());
+        $tag->initialize($line);
+        $this->assertSame($expectedTypes, $tag->getTypes());
+        $this->assertSame($expectedVariableName, $tag->getVariableName());
+        $this->assertSame($expectedDescription, $tag->getDescription());
     }
 
-    public function testParseTypeAndName()
+    public function varTagProvider(): array
     {
-        $tag = new VarTag();
-        $tag->initialize('string|null $test');
-        $this->assertEquals('$test', $tag->getVariableName());
-        $this->assertNull($tag->getDescription());
-        $this->assertEquals(['string', 'null'], $tag->getTypes());
-    }
+        return [
+            'only type' => [
+                'string',
+                ['string'],
+                null,
+                null
+            ],
+            'only multiple types' => [
+                'string|int',
+                ['string', 'int'],
+                null,
+                null
+            ],
+            'type and name' => [
+                'string $test',
+                ['string'],
+                '$test',
+                null
+            ],
+            'multiple types and name' => [
+                'string|int $test',
+                ['string', 'int'],
+                '$test',
+                null
+            ],
+            'only name' => [
+                '$test',
+                [],
+                '$test',
+                null
+            ],
+            'name and description' => [
+                '$test Foo Bar',
+                [],
+                '$test',
+                'Foo Bar'
+            ],
+            'type and description' => [
+                'string Foo bar',
+                ['string'],
+                null,
+                'Foo bar'
+            ],
+            'multiple types and description' => [
+                'string|int Foo bar',
+                ['string', 'int'],
+                null,
+                'Foo bar'
+            ],
+            'type, name and description' => [
+                'string $test Foo bar',
+                ['string'],
+                '$test',
+                'Foo bar'
+            ],
+            'multiple types, name and description' => [
+                'string|int $test Foo bar',
+                ['string', 'int'],
+                '$test',
+                'Foo bar'
+            ],
 
-    public function testParseNameAndDescription()
-    {
-        $tag = new VarTag();
-        $tag->initialize('$test I\'m test property');
-        $this->assertEquals('$test', $tag->getVariableName());
-        $this->assertEquals('I\'m test property', $tag->getDescription());
-    }
-
-    public function testParseTypeAndNameAndDescription()
-    {
-        $tag = new VarTag();
-        $tag->initialize('string $test I\'m test variable');
-        $this->assertEquals('$test', $tag->getVariableName());
-        $this->assertEquals('I\'m test variable', $tag->getDescription());
+        ];
     }
 }

--- a/test/Reflection/ReflectionDocBlockTagTest.php
+++ b/test/Reflection/ReflectionDocBlockTagTest.php
@@ -10,6 +10,7 @@
 namespace ZendTest\Code\Reflection;
 
 use PHPUnit\Framework\TestCase;
+use Zend\Code\Generator\DocBlock\Tag\VarTag;
 use Zend\Code\Reflection;
 
 /**
@@ -41,8 +42,16 @@ class ReflectionDocBlockTagTest extends TestCase
         $classReflection = new Reflection\ClassReflection(TestAsset\TestSampleClass6::class);
 
         $tag = $classReflection->getMethod('doSomething')->getDocBlock()->getTag('descriptionTag');
-        self::assertNotEquals('          A tag with just a description', $tag->getContent(), 'Final Match Failed');
-        self::assertEquals('A tag with just a description', $tag->getContent(), 'Final Match Failed');
+        self::assertNotEquals(
+            '          A tag with just a description',
+            $tag->getContent(),
+            'Final Match Failed'
+        );
+        self::assertEquals(
+            'A tag with just a description',
+            $tag->getContent(),
+            'Final Match Failed'
+        );
     }
 
     public function testToString()
@@ -53,7 +62,7 @@ class ReflectionDocBlockTagTest extends TestCase
 
         $expectedString = 'DocBlock Tag [ * @descriptionTag ]' . "\n";
 
-        self::assertEquals($expectedString, (string) $tag);
+        self::assertEquals($expectedString, (string)$tag);
     }
 
     public function testTypeParam()
@@ -79,10 +88,13 @@ class ReflectionDocBlockTagTest extends TestCase
 
         $paramTag = $classReflection->getMethod('doSomething')->getDocBlock()->getTag('param');
 
-
         self::assertEquals('int', $paramTag->getType(), 'Second Match Failed');
         self::assertEquals('$var', $paramTag->getVariableName(), 'Third Match Failed');
-        self::assertEquals('Description of $var', $paramTag->getDescription(), 'Final Match Failed');
+        self::assertEquals(
+            'Description of $var',
+            $paramTag->getDescription(),
+            'Final Match Failed'
+        );
     }
 
     /**
@@ -91,8 +103,7 @@ class ReflectionDocBlockTagTest extends TestCase
     public function testNamespaceInParam()
     {
         $classReflection = new Reflection\ClassReflection(TestAsset\TestSampleClass7::class);
-        $paramTag        = $classReflection->getMethod('doSomething')->getDocBlock()->getTag('param');
-
+        $paramTag = $classReflection->getMethod('doSomething')->getDocBlock()->getTag('param');
 
         self::assertEquals('Zend\Foo\Bar', $paramTag->getType());
         self::assertEquals('$var', $paramTag->getVariableName());
@@ -114,7 +125,11 @@ class ReflectionDocBlockTagTest extends TestCase
         $paramTag = $classReflection->getMethod('doSomething')->getDocBlock()->getTag('return');
 
         self::assertEquals('string', $paramTag->getType(), 'Second Match Failed');
-        self::assertEquals('Description of return value', $paramTag->getDescription(), 'Final Match Failed');
+        self::assertEquals(
+            'Description of return value',
+            $paramTag->getDescription(),
+            'Final Match Failed'
+        );
     }
 
     /**
@@ -127,5 +142,49 @@ class ReflectionDocBlockTagTest extends TestCase
         $paramTag = $classReflection->getMethod('doSomething')->getDocBlock()->getTag('return');
 
         self::assertEquals('Zend\Code\Reflection\DocBlock', $paramTag->getType());
+    }
+
+    /**
+     * @dataProvider propertyVarDocProvider
+     */
+    public function testPropertyVarDoc(
+        string $property,
+        array $expectedTypes,
+        ?string $expectedName,
+        ?string $expectedDescription
+    ) {
+        $classReflection = new Reflection\ClassReflection(
+            TestAsset\TestSampleClass14::class
+        );
+
+        /** @var VarTag $varTag */
+        $varTag = $classReflection
+            ->getProperty($property)
+            ->getDocBlock()
+            ->getTag('var');
+
+        self::assertSame($expectedTypes, $varTag->getTypes());
+        self::assertSame($expectedName, $varTag->getVariableName());
+        self::assertSame($expectedDescription, $varTag->getDescription());
+    }
+
+    public function propertyVarDocProvider(): array
+    {
+        return [
+            'only type' => ['onlyType', ['string'], null, null],
+            'type and description' => [
+                'typeDescription',
+                ['string'],
+                null,
+                'Foo bar'
+            ],
+            'type and name' => ['typeName', ['string'], '$typeName', null],
+            'type, name and description' => [
+                'typeNameDescription',
+                ['string'],
+                '$typeNameDescription',
+                'Foo bar'
+            ],
+        ];
     }
 }

--- a/test/Reflection/TestAsset/TestSampleClass14.php
+++ b/test/Reflection/TestAsset/TestSampleClass14.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * @author     Pieter Wiersema <p.wiersema@allcode.nl>
+ * @copyright  Copyright (c) 2011-now AllCode, https://allcode.nl
+ */
+
+namespace ZendTest\Code\Reflection\TestAsset;
+
+class TestSampleClass14
+{
+    /**
+     * @var string
+     */
+    public $onlyType;
+
+    /**
+     * @var string Foo bar
+     */
+    public $typeDescription;
+
+    /**
+     * @var string $typeName
+     */
+    public $typeName;
+
+    /**
+     * @var string $typeNameDescription Foo bar
+     */
+    public $typeNameDescription;
+}


### PR DESCRIPTION
Var tag pattern now allows var tags without the variable name. This fixes #128.