### PR TITLE
ParserInterface segregation

### DIFF
--- a/src/Annotation/AnnotationManager.php
+++ b/src/Annotation/AnnotationManager.php
@@ -9,7 +9,7 @@
 
 namespace Zend\Code\Annotation;
 
-use Zend\Code\Annotation\Parser\ParserInterface;
+use Zend\Code\Annotation\Parser\EventAwareInterface;
 use Zend\EventManager\Event;
 use Zend\EventManager\EventManager;
 use Zend\EventManager\EventManagerAwareInterface;
@@ -72,10 +72,10 @@ class AnnotationManager implements EventManagerAwareInterface
     /**
      * Attach a parser to listen to the createAnnotation event
      *
-     * @param  ParserInterface $parser
+     * @param  EventAwareInterface $parser
      * @return AnnotationManager
      */
-    public function attach(ParserInterface $parser)
+    public function attach(EventAwareInterface $parser)
     {
         $this->getEventManager()
              ->attach(self::EVENT_CREATE_ANNOTATION, [$parser, 'onCreateAnnotation']);

--- a/src/Annotation/Parser/AnnotationRegistryInterface.php
+++ b/src/Annotation/Parser/AnnotationRegistryInterface.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Code\Annotation\Parser;
+
+use Zend\EventManager\EventInterface;
+
+interface AnnotationRegistryInterface
+{
+    /**
+     * Register an annotation this parser will accept
+     *
+     * @param  mixed $annotation
+     * @return void
+     */
+    public function registerAnnotation($annotation);
+
+    /**
+     * Register multiple annotations this parser will accept
+     *
+     * @param  array|\Traversable $annotations
+     * @return void
+     */
+    public function registerAnnotations($annotations);
+}

--- a/src/Annotation/Parser/EventAwareInterface.php
+++ b/src/Annotation/Parser/EventAwareInterface.php
@@ -11,4 +11,13 @@ namespace Zend\Code\Annotation\Parser;
 
 use Zend\EventManager\EventInterface;
 
-interface ParserInterface extends EventAwareInterface, AnnotationRegistryInterface {}
+interface EventAwareInterface
+{
+    /**
+     * Respond to the "createAnnotation" event
+     *
+     * @param  EventInterface  $e
+     * @return false|\stdClass
+     */
+    public function onCreateAnnotation(EventInterface $e);
+}


### PR DESCRIPTION
Hello everybody. 

Have some problem with ParserInterface. If i would have a custom implementation and method signature for the registerAnnotation, or do not want to have registerAnnotations it is not affect the Parser functionality, so why it is defined in ParserInterface ?
Additionally it is really miss used in AnnotationManager.php, only one method required to make the Parser attachable to the EventManager, but method signature requires to implement whole interface. 

So i would suggest to split this interface to few more specific. And for BC, i would suggest to not remove ParserInterface but do inheritance inside it, to inherit a two more specific contracts.

What do you think ?