### PR TITLE
Replace "continue" by "break" in "switch" statements

### DIFF
--- a/src/Generator/FileGenerator.php
+++ b/src/Generator/FileGenerator.php
@@ -155,17 +155,17 @@ class FileGenerator extends AbstractGenerator
             switch (strtolower(str_replace(['.', '-', '_'], '', $name))) {
                 case 'filename':
                     $fileGenerator->setFilename($value);
-                    continue;
+                    break;
                 case 'class':
                     $fileGenerator->setClass(
                         $value instanceof ClassGenerator
                         ? $value
                         : ClassGenerator::fromArray($value)
                     );
-                    continue;
+                    break;
                 case 'requiredfiles':
                     $fileGenerator->setRequiredFiles($value);
-                    continue;
+                    break;
                 default:
                     if (property_exists($fileGenerator, $name)) {
                         $fileGenerator->{$name} = $value;

--- a/src/Reflection/MethodReflection.php
+++ b/src/Reflection/MethodReflection.php
@@ -287,22 +287,22 @@ class MethodReflection extends PhpReflectionMethod implements ReflectionInterfac
                         //closure test
                         if ($firstBrace && $tokenType == 'T_FUNCTION') {
                             $body .= $tokenValue;
-                            continue;
+                            break;
                         }
                         $capture = false;
-                        continue;
+                        break;
                     }
                     break;
 
                 case '{':
                     if ($capture === false) {
-                        continue;
+                        break;
                     }
 
                     if ($firstBrace === false) {
                         $firstBrace = true;
                         if ($bodyOnly === true) {
-                            continue;
+                            break;
                         }
                     }
 
@@ -311,7 +311,7 @@ class MethodReflection extends PhpReflectionMethod implements ReflectionInterfac
 
                 case '}':
                     if ($capture === false) {
-                        continue;
+                        break;
                     }
 
                     //check to see if this is the last brace
@@ -329,12 +329,12 @@ class MethodReflection extends PhpReflectionMethod implements ReflectionInterfac
 
                 default:
                     if ($capture === false) {
-                        continue;
+                        break;
                     }
 
                     // if returning body only wait for first brace before capturing
                     if ($bodyOnly === true && $firstBrace !== true) {
-                        continue;
+                        break;
                     }
 
                     $body .= $tokenValue;


### PR DESCRIPTION
Removes related deprecations when running with PHP 7.3.