### PR TITLE
Added PHP 7.3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,15 @@ matrix:
     - php: 7.2
       env:
         - DEPS=latest
+    - php: 7.3
+      env:
+        - DEPS=lowest
+    - php: 7.3
+      env:
+        - DEPS=locked
+    - php: 7.3
+      env:
+        - DEPS=latest
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi


### PR DESCRIPTION
Updated Travis CI configuration to run all tests on PHP 7.3 with lowest/locked/latest dependencies