### PR TITLE
Feature: Add ability to define declare statements

### DIFF
--- a/src/DeclareStatement.php
+++ b/src/DeclareStatement.php
@@ -4,7 +4,7 @@ namespace Zend\Code;
 
 use Zend\Code\Exception\InvalidArgumentException;
 
-class Declare_
+class DeclareStatement
 {
     public const TICKS = 'ticks';
     public const STRICT_TYPES = 'strict_types';
@@ -50,32 +50,32 @@ class Declare_
 
     /**
      * @param int $value
-     * @return Declare_
+     * @return DeclareStatement
      */
-    public static function ticks(int $value): Declare_
+    public static function ticks(int $value): DeclareStatement
     {
         return new self(self::TICKS, $value);
     }
 
     /**
      * @param int $value
-     * @return Declare_
+     * @return DeclareStatement
      */
-    public static function strictTypes(int $value): Declare_
+    public static function strictTypes(int $value): DeclareStatement
     {
         return new self(self::STRICT_TYPES, $value);
     }
 
     /**
      * @param string $value
-     * @return Declare_
+     * @return DeclareStatement
      */
-    public static function encoding(string $value): Declare_
+    public static function encoding(string $value): DeclareStatement
     {
         return new self(self::ENCODING, $value);
     }
 
-    public static function fromArray(array $config): Declare_
+    public static function fromArray(array $config): DeclareStatement
     {
         $directive = key($config);
         $value = $config[$directive];

--- a/src/DeclareStatement.php
+++ b/src/DeclareStatement.php
@@ -13,7 +13,7 @@ class DeclareStatement
     private const ALLOWED = [
         self::TICKS        => 'integer',
         self::STRICT_TYPES => 'integer',
-        self::ENCODING     => 'string'
+        self::ENCODING     => 'string',
     ];
 
     /**
@@ -50,37 +50,37 @@ class DeclareStatement
 
     /**
      * @param int $value
-     * @return DeclareStatement
+     * @return self
      */
-    public static function ticks(int $value): DeclareStatement
+    public static function ticks(int $value): self
     {
         return new self(self::TICKS, $value);
     }
 
     /**
      * @param int $value
-     * @return DeclareStatement
+     * @return self
      */
-    public static function strictTypes(int $value): DeclareStatement
+    public static function strictTypes(int $value): self
     {
         return new self(self::STRICT_TYPES, $value);
     }
 
     /**
      * @param string $value
-     * @return DeclareStatement
+     * @return self
      */
-    public static function encoding(string $value): DeclareStatement
+    public static function encoding(string $value): self
     {
         return new self(self::ENCODING, $value);
     }
 
-    public static function fromArray(array $config): DeclareStatement
+    public static function fromArray(array $config): self
     {
         $directive = key($config);
         $value = $config[$directive];
 
-        if (! array_key_exists($directive, self::ALLOWED)) {
+        if (! isset(self::ALLOWED[$directive])) {
             throw new InvalidArgumentException(
                 sprintf(
                     'Declare directive must be on of: %s.',
@@ -100,6 +100,7 @@ class DeclareStatement
         }
 
         $method = str_replace('_', '', lcfirst(ucwords($directive, '_')));
+
         return self::{$method}($value);
     }
 

--- a/src/DeclareStatement.php
+++ b/src/DeclareStatement.php
@@ -83,7 +83,7 @@ class DeclareStatement
         if (! isset(self::ALLOWED[$directive])) {
             throw new InvalidArgumentException(
                 sprintf(
-                    'Declare directive must be on of: %s.',
+                    'Declare directive must be one of: %s.',
                     implode(', ', array_keys(self::ALLOWED))
                 )
             );
@@ -92,7 +92,7 @@ class DeclareStatement
         if (gettype($value) !== self::ALLOWED[$directive]) {
             throw new InvalidArgumentException(
                 sprintf(
-                    'Declare value invalid. Expected %s got %s.',
+                    'Declare value invalid. Expected %s, got %s.',
                     self::ALLOWED[$directive],
                     gettype($value)
                 )

--- a/src/Declare_.php
+++ b/src/Declare_.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Zend\Code;
+
+use Zend\Code\Exception\InvalidArgumentException;
+
+class Declare_
+{
+    public const TICKS = 'ticks';
+    public const STRICT_TYPES = 'strict_types';
+    public const ENCODING = 'encoding';
+
+    private const ALLOWED = [
+        self::TICKS        => 'integer',
+        self::STRICT_TYPES => 'integer',
+        self::ENCODING     => 'string'
+    ];
+
+    /**
+     * @var string
+     */
+    protected $directive;
+
+    /**
+     * @var int|string
+     */
+    protected $value;
+
+    private function __construct(string $directive, $value)
+    {
+        $this->directive = $directive;
+        $this->value = $value;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDirective(): string
+    {
+        return $this->directive;
+    }
+
+    /**
+     * @return int|string
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    /**
+     * @param int $value
+     * @return Declare_
+     */
+    public static function ticks(int $value): Declare_
+    {
+        return new self(self::TICKS, $value);
+    }
+
+    /**
+     * @param int $value
+     * @return Declare_
+     */
+    public static function strictTypes(int $value): Declare_
+    {
+        return new self(self::STRICT_TYPES, $value);
+    }
+
+    /**
+     * @param string $value
+     * @return Declare_
+     */
+    public static function encoding(string $value): Declare_
+    {
+        return new self(self::ENCODING, $value);
+    }
+
+    public static function fromArray(array $config): Declare_
+    {
+        $directive = array_key_first($config);
+        $value = $config[$directive];
+
+        if (! array_key_exists($directive, self::ALLOWED)) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Declare directive must be on of: %s.',
+                    implode(', ', array_keys(self::ALLOWED))
+                )
+            );
+        }
+
+        if (gettype($value) !== self::ALLOWED[$directive]) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Declare value invalid. Expected %s got %s.',
+                    self::ALLOWED[$directive],
+                    gettype($value)
+                )
+            );
+        }
+
+        $method = str_replace('_', '', lcfirst(ucwords($directive, '_')));
+        return self::{$method}($value);
+    }
+
+    /**
+     * @return string
+     */
+    public function getStatement(): string
+    {
+        $value = is_string($this->value) ? '\'' . $this->value . '\'' : $this->value;
+
+        return sprintf('declare(%s=%s);', $this->directive, $value);
+    }
+}

--- a/src/Declare_.php
+++ b/src/Declare_.php
@@ -77,7 +77,7 @@ class Declare_
 
     public static function fromArray(array $config): Declare_
     {
-        $directive = array_key_first($config);
+        $directive = key($config);
         $value = $config[$directive];
 
         if (! array_key_exists($directive, self::ALLOWED)) {

--- a/src/Generator/FileGenerator.php
+++ b/src/Generator/FileGenerator.php
@@ -174,7 +174,7 @@ class FileGenerator extends AbstractGenerator
                     $fileGenerator->setRequiredFiles($value);
                     break;
                 case 'declares':
-                    $fileGenerator->setDeclares(array_map(function ($directive, $value) {
+                    $fileGenerator->setDeclares(array_map(static function ($directive, $value) {
                         return DeclareStatement::fromArray([$directive => $value]);
                     }, array_keys($value), $value));
                     break;
@@ -425,9 +425,9 @@ class FileGenerator extends AbstractGenerator
         foreach ($declares as $declare) {
             if (! $declare instanceof DeclareStatement) {
                 throw new InvalidArgumentException(sprintf(
-                    '%s is expecting an array of %s\Declare objects',
+                    '%s is expecting an array of %s objects',
                     __METHOD__,
-                    __NAMESPACE__
+                    DeclareStatement::class
                 ));
             }
 

--- a/src/Generator/FileGenerator.php
+++ b/src/Generator/FileGenerator.php
@@ -9,7 +9,7 @@
 
 namespace Zend\Code\Generator;
 
-use Zend\Code\Declare_;
+use Zend\Code\DeclareStatement;
 use Zend\Code\Exception\InvalidArgumentException;
 use Zend\Code\Reflection\Exception as ReflectionException;
 use Zend\Code\Reflection\FileReflection;
@@ -75,7 +75,7 @@ class FileGenerator extends AbstractGenerator
     protected $body;
 
     /**
-     * @var Declare_[]
+     * @var DeclareStatement[]
      */
     protected $declares = [];
 
@@ -175,7 +175,7 @@ class FileGenerator extends AbstractGenerator
                     break;
                 case 'declares':
                     $fileGenerator->setDeclares(array_map(function ($directive, $value) {
-                        return Declare_::fromArray([$directive => $value]);
+                        return DeclareStatement::fromArray([$directive => $value]);
                     }, array_keys($value), $value));
                     break;
                 default:
@@ -423,7 +423,7 @@ class FileGenerator extends AbstractGenerator
     public function setDeclares(array $declares)
     {
         foreach ($declares as $declare) {
-            if (! $declare instanceof Declare_) {
+            if (! $declare instanceof DeclareStatement) {
                 throw new InvalidArgumentException(sprintf(
                     '%s is expecting an array of %s\Declare objects',
                     __METHOD__,

--- a/src/Generator/FileGenerator.php
+++ b/src/Generator/FileGenerator.php
@@ -9,6 +9,8 @@
 
 namespace Zend\Code\Generator;
 
+use Zend\Code\Declare_;
+use Zend\Code\Exception\InvalidArgumentException;
 use Zend\Code\Reflection\Exception as ReflectionException;
 use Zend\Code\Reflection\FileReflection;
 
@@ -71,6 +73,11 @@ class FileGenerator extends AbstractGenerator
      * @var string
      */
     protected $body;
+
+    /**
+     * @var Declare_[]
+     */
+    protected $declares = [];
 
     /**
      * Passes $options to {@link setOptions()}.
@@ -165,6 +172,11 @@ class FileGenerator extends AbstractGenerator
                     break;
                 case 'requiredfiles':
                     $fileGenerator->setRequiredFiles($value);
+                    break;
+                case 'declares':
+                    $fileGenerator->setDeclares(array_map(function ($directive, $value) {
+                        return Declare_::fromArray([$directive => $value]);
+                    }, array_keys($value), $value));
                     break;
                 default:
                     if (property_exists($fileGenerator, $name)) {
@@ -408,6 +420,25 @@ class FileGenerator extends AbstractGenerator
         return $this->body;
     }
 
+    public function setDeclares(array $declares)
+    {
+        foreach ($declares as $declare) {
+            if (! $declare instanceof Declare_) {
+                throw new InvalidArgumentException(sprintf(
+                    '%s is expecting an array of %s\Declare objects',
+                    __METHOD__,
+                    __NAMESPACE__
+                ));
+            }
+
+            if (! array_key_exists($declare->getDirective(), $this->declares)) {
+                $this->declares[$declare->getDirective()] = $declare;
+            }
+        }
+
+        return $this;
+    }
+
     /**
      * @return bool
      */
@@ -489,6 +520,28 @@ class FileGenerator extends AbstractGenerator
             } else {
                 $output .= $namespace;
             }
+        }
+
+        // declares, if any
+        if ($this->declares) {
+            $declareStatements = '';
+
+            foreach ($this->declares as $declare) {
+                $declareStatements .= $declare->getStatement() . self::LINE_FEED;
+            }
+
+            if (preg_match('#/\* Zend_Code_Generator_FileGenerator-DeclaresMarker \*/#m', $output)) {
+                $output = preg_replace(
+                    '#/\* Zend_Code_Generator_FileGenerator-DeclaresMarker \*/#m',
+                    $declareStatements,
+                    $output,
+                    1
+                );
+            } else {
+                $output .= $declareStatements;
+            }
+
+            $output .= self::LINE_FEED;
         }
 
         // process required files

--- a/test/Generator/FileGeneratorTest.php
+++ b/test/Generator/FileGeneratorTest.php
@@ -483,7 +483,7 @@ EOS;
     public function testDeclareUnknownDirectiveShouldRaiseException(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Declare directive must be on of: ticks, strict_types, encoding.');
+        $this->expectExceptionMessage('Declare directive must be one of: ticks, strict_types, encoding.');
 
         FileGenerator::fromArray([
             'declares' => [
@@ -498,7 +498,7 @@ EOS;
     public function testDeclareWrongTypeShouldRaiseException(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Declare value invalid. Expected integer got string.');
+        $this->expectExceptionMessage('Declare value invalid. Expected integer, got string.');
 
         FileGenerator::fromArray([
             'declares' => [

--- a/test/Generator/FileGeneratorTest.php
+++ b/test/Generator/FileGeneratorTest.php
@@ -420,10 +420,10 @@ CODE;
     {
         $generator = FileGenerator::fromArray([
             'declares' => [
-                'strict_types' => 1
+                'strict_types' => 1,
             ],
             'class' => [
-                'name' => 'SampleClass'
+                'name' => 'SampleClass',
             ],
         ]);
         $generator->setFilename(sys_get_temp_dir() . '/result_file.php');
@@ -452,10 +452,10 @@ EOS;
         $generator = FileGenerator::fromArray([
             'declares' => [
                 'strict_types' => 1,
-                'ticks' => 2
+                'ticks' => 2,
             ],
             'class' => [
-                'name' => 'SampleClass'
+                'name' => 'SampleClass',
             ],
         ]);
         $generator->setFilename(sys_get_temp_dir() . '/result_file.php');
@@ -487,10 +487,10 @@ EOS;
 
         FileGenerator::fromArray([
             'declares' => [
-                'fubar' => 1
+                'fubar' => 1,
             ],
             'class' => [
-                'name' => 'SampleClass'
+                'name' => 'SampleClass',
             ],
         ]);
     }
@@ -502,10 +502,10 @@ EOS;
 
         FileGenerator::fromArray([
             'declares' => [
-                'strict_types' => 'wrong type'
+                'strict_types' => 'wrong type',
             ],
             'class' => [
-                'name' => 'SampleClass'
+                'name' => 'SampleClass',
             ],
         ]);
     }
@@ -514,7 +514,7 @@ EOS;
     {
         $generator = FileGenerator::fromArray([
             'class' => [
-                'name' => 'SampleClass'
+                'name' => 'SampleClass',
             ],
         ]);
         $generator->setFilename(sys_get_temp_dir() . '/result_file.php');

--- a/test/Generator/FileGeneratorTest.php
+++ b/test/Generator/FileGeneratorTest.php
@@ -541,4 +541,13 @@ EOS;
         $actual = file_get_contents(sys_get_temp_dir() . '/result_file.php');
         $this->assertEquals($expected, $actual);
     }
+
+    public function testWrongDeclareTypeShouldRaiseException(): void
+    {
+        $generator = new FileGenerator();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('setDeclares is expecting an array of Zend\\Code\\DeclareStatement objects');
+        $generator->setDeclares([new \stdClass()]);
+    }
 }

--- a/test/Generator/FileGeneratorTest.php
+++ b/test/Generator/FileGeneratorTest.php
@@ -10,7 +10,7 @@
 namespace ZendTest\Code\Generator;
 
 use PHPUnit\Framework\TestCase;
-use Zend\Code\Declare_;
+use Zend\Code\DeclareStatement;
 use Zend\Code\Exception\InvalidArgumentException;
 use Zend\Code\Generator\ClassGenerator;
 use Zend\Code\Generator\FileGenerator;
@@ -519,8 +519,8 @@ EOS;
         ]);
         $generator->setFilename(sys_get_temp_dir() . '/result_file.php');
         $generator->setDeclares([
-            Declare_::strictTypes(1),
-            Declare_::strictTypes(2)
+            DeclareStatement::strictTypes(1),
+            DeclareStatement::strictTypes(2)
         ]);
         $generator->write();
 

--- a/test/Generator/FileGeneratorTest.php
+++ b/test/Generator/FileGeneratorTest.php
@@ -483,7 +483,7 @@ EOS;
     public function testDeclareUnknownDirectiveShouldRaiseException(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Declare directive must be on of: tick, strict_types, encoding.');
+        $this->expectExceptionMessage('Declare directive must be on of: ticks, strict_types, encoding.');
 
         FileGenerator::fromArray([
             'declares' => [


### PR DESCRIPTION
This will add the ability to configure declare() statements
at the top of generated files. 

I took the implementation suggestion from @GaryJones in #102 and changes it a bit.
I changed the behavior to be only able to generate valid `declare` statements at all.
Also I added static factories to generate the possible directives.

Should solve #102

---

~One problem tho. Since `declare` is a reserved keyword. The I decided to go with `Declare_` as the class representation. But the codesniffer doesn't like this. Any suggestions?~ Renamed to `DeclareStatement` as suggested by @webimpress 