### PR TITLE
Feature: constant visibility

### DIFF
--- a/src/Generator/PropertyGenerator.php
+++ b/src/Generator/PropertyGenerator.php
@@ -157,7 +157,6 @@ class PropertyGenerator extends AbstractMemberGenerator
     public function setConst($const)
     {
         if ($const) {
-            $this->removeFlag(self::FLAG_PUBLIC | self::FLAG_PRIVATE | self::FLAG_PROTECTED);
             $this->setFlags(self::FLAG_CONSTANT);
         } else {
             $this->removeFlag(self::FLAG_CONSTANT);
@@ -227,7 +226,7 @@ class PropertyGenerator extends AbstractMemberGenerator
                     $this->name
                 ));
             }
-            $output .= $this->indentation . 'const ' . $name . ' = '
+            $output .= $this->indentation . $this->getVisibility() . ' const ' . $name . ' = '
                 . ($defaultValue !== null ? $defaultValue->generate() : 'null;');
 
             return $output;

--- a/test/Generator/ClassGeneratorTest.php
+++ b/test/Generator/ClassGeneratorTest.php
@@ -802,7 +802,7 @@ namespace ZendTest\Code\Generator\TestAsset;
 class TestSampleSingleClass
 {
 
-    const fooProperty = 'duplicate';
+    public const fooProperty = 'duplicate';
 
     public $fooProperty = true;
 

--- a/test/Generator/InterfaceGeneratorTest.php
+++ b/test/Generator/InterfaceGeneratorTest.php
@@ -152,9 +152,9 @@ namespace ZendTest\Code\TestAsset;
 interface FooInterface
 {
 
-    const BAR = 5;
+    public const BAR = 5;
 
-    const FOO = 5;
+    public const FOO = 5;
 
     public function fooBarBaz();
 

--- a/test/Generator/PropertyGeneratorTest.php
+++ b/test/Generator/PropertyGeneratorTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\Code\Generator;
 
+use Generator;
 use PHPUnit\Framework\TestCase;
 use Zend\Code\Generator\DocBlock\Tag\VarTag;
 use Zend\Code\Generator\DocBlockGenerator;
@@ -126,10 +127,26 @@ EOS;
         self::assertEquals($expectedSource, $targetSource);
     }
 
+    public function visibility() : Generator
+    {
+        yield 'public' => [PropertyGenerator::FLAG_PUBLIC, 'public'];
+        yield 'protected' => [PropertyGenerator::FLAG_PROTECTED, 'protected'];
+        yield 'private' => [PropertyGenerator::FLAG_PRIVATE, 'private'];
+    }
+
+    /**
+     * @dataProvider visibility
+     */
+    public function testPropertyCanProduceConstatWithVisibility(int $flag, string $visibility) : void
+    {
+        $codeGenProperty = new PropertyGenerator('FOO', 'bar', [PropertyGenerator::FLAG_CONSTANT, $flag]);
+        self::assertSame('    ' . $visibility . ' const FOO = \'bar\';', $codeGenProperty->generate());
+    }
+
     public function testPropertyCanProduceContstantModifier() : void
     {
         $codeGenProperty = new PropertyGenerator('someVal', 'some string value', PropertyGenerator::FLAG_CONSTANT);
-        self::assertEquals('    const someVal = \'some string value\';', $codeGenProperty->generate());
+        self::assertEquals('    public const someVal = \'some string value\';', $codeGenProperty->generate());
     }
 
     /**
@@ -139,7 +156,7 @@ EOS;
     {
         $codeGenProperty = new PropertyGenerator('someVal', 'some string value');
         $codeGenProperty->setConst(true);
-        self::assertEquals('    const someVal = \'some string value\';', $codeGenProperty->generate());
+        self::assertEquals('    public const someVal = \'some string value\';', $codeGenProperty->generate());
     }
 
     public function testPropertyCanProduceStaticModifier() : void

--- a/test/Generator/ValueGeneratorTest.php
+++ b/test/Generator/ValueGeneratorTest.php
@@ -92,7 +92,7 @@ class ValueGeneratorTest extends TestCase
         return [
             [
                 new PropertyValueGenerator([], PropertyValueGenerator::TYPE_ARRAY, ValueGenerator::OUTPUT_SINGLE_LINE),
-                '    const FOO = [];',
+                '    public const FOO = [];',
             ],
             [
                 new PropertyValueGenerator(
@@ -100,7 +100,7 @@ class ValueGeneratorTest extends TestCase
                     PropertyValueGenerator::TYPE_ARRAY_LONG,
                     ValueGenerator::OUTPUT_SINGLE_LINE
                 ),
-                '    const FOO = array();',
+                '    public const FOO = array();',
             ],
             [
                 new PropertyValueGenerator(
@@ -108,17 +108,20 @@ class ValueGeneratorTest extends TestCase
                     PropertyValueGenerator::TYPE_ARRAY_SHORT,
                     ValueGenerator::OUTPUT_SINGLE_LINE
                 ),
-                '    const FOO = [];',
+                '    public const FOO = [];',
             ],
-            [new PropertyValueGenerator(true, PropertyValueGenerator::TYPE_BOOL), '    const FOO = true;'],
-            [new PropertyValueGenerator(true, PropertyValueGenerator::TYPE_BOOLEAN), '    const FOO = true;'],
-            [new PropertyValueGenerator(1, PropertyValueGenerator::TYPE_INT), '    const FOO = 1;'],
-            [new PropertyValueGenerator(1, PropertyValueGenerator::TYPE_INTEGER), '    const FOO = 1;'],
-            [new PropertyValueGenerator(0.1, PropertyValueGenerator::TYPE_DOUBLE), '    const FOO = 0.1;'],
-            [new PropertyValueGenerator(0.1, PropertyValueGenerator::TYPE_FLOAT), '    const FOO = 0.1;'],
-            [new PropertyValueGenerator('bar', PropertyValueGenerator::TYPE_STRING), "    const FOO = 'bar';"],
-            [new PropertyValueGenerator(null, PropertyValueGenerator::TYPE_NULL), '    const FOO = null;'],
-            [new PropertyValueGenerator('PHP_EOL', PropertyValueGenerator::TYPE_CONSTANT), '    const FOO = PHP_EOL;'],
+            [new PropertyValueGenerator(true, PropertyValueGenerator::TYPE_BOOL), '    public const FOO = true;'],
+            [new PropertyValueGenerator(true, PropertyValueGenerator::TYPE_BOOLEAN), '    public const FOO = true;'],
+            [new PropertyValueGenerator(1, PropertyValueGenerator::TYPE_INT), '    public const FOO = 1;'],
+            [new PropertyValueGenerator(1, PropertyValueGenerator::TYPE_INTEGER), '    public const FOO = 1;'],
+            [new PropertyValueGenerator(0.1, PropertyValueGenerator::TYPE_DOUBLE), '    public const FOO = 0.1;'],
+            [new PropertyValueGenerator(0.1, PropertyValueGenerator::TYPE_FLOAT), '    public const FOO = 0.1;'],
+            [new PropertyValueGenerator('bar', PropertyValueGenerator::TYPE_STRING), "    public const FOO = 'bar';"],
+            [new PropertyValueGenerator(null, PropertyValueGenerator::TYPE_NULL), '    public const FOO = null;'],
+            [
+                new PropertyValueGenerator('PHP_EOL', PropertyValueGenerator::TYPE_CONSTANT),
+                '    public const FOO = PHP_EOL;',
+            ],
         ];
     }
 

--- a/test/TestAsset/BarClass.php
+++ b/test/TestAsset/BarClass.php
@@ -9,8 +9,8 @@ use Foo\Bar\Baz as FooBarBaz;
 
 abstract class BarClass
 {
-    const BAR = 5;
-    const FOO = self::BAR;
+    public const BAR = 5;
+    public const FOO = self::BAR;
 
     protected static $bar = 'value';
 

--- a/test/TestAsset/FooClass.php
+++ b/test/TestAsset/FooClass.php
@@ -10,8 +10,8 @@ use Foo\Bar\Baz as FooBarBaz;
 
 abstract class FooClass implements \ArrayAccess, E\Blarg, Local\SubClass
 {
-    const BAR = 5;
-    const FOO = self::BAR;
+    public const BAR = 5;
+    public const FOO = self::BAR;
 
     /**
      * Constant comment

--- a/test/TestAsset/FooInterface.php
+++ b/test/TestAsset/FooInterface.php
@@ -11,8 +11,8 @@ namespace ZendTest\Code\TestAsset;
 
 interface FooInterface extends \ArrayAccess
 {
-    const BAR = 5;
-    const FOO = self::BAR;
+    public const BAR = 5;
+    public const FOO = self::BAR;
 
     public function fooBarBaz();
 


### PR DESCRIPTION
As we support already only PHP 7.1+ we can define visibility for constants.

Added tests and updated current tests.
Default visibility is `public`.