### PR TITLE
Fix: replace curly offset access brace with square brackets

### DIFF
--- a/src/NameInformation.php
+++ b/src/NameInformation.php
@@ -141,11 +141,11 @@ class NameInformation
      */
     public function resolveName($name)
     {
-        if ($this->namespace && ! $this->uses && strlen($name) > 0 && $name{0} != '\\') {
+        if ($this->namespace && ! $this->uses && strlen($name) > 0 && $name[0] != '\\') {
             return $this->namespace . '\\' . $name;
         }
 
-        if (! $this->uses || strlen($name) <= 0 || $name{0} == '\\') {
+        if (! $this->uses || strlen($name) <= 0 || $name[0] == '\\') {
             return ltrim($name, '\\');
         }
 

--- a/src/Scanner/Util.php
+++ b/src/Scanner/Util.php
@@ -48,13 +48,13 @@ class Util
             ));
         }
 
-        if ($data->namespace && ! $data->uses && strlen($value) > 0 && $value{0} != '\\') {
+        if ($data->namespace && ! $data->uses && strlen($value) > 0 && $value[0] != '\\') {
             $value = $data->namespace . '\\' . $value;
 
             return;
         }
 
-        if (! $data->uses || strlen($value) <= 0 || $value{0} == '\\') {
+        if (! $data->uses || strlen($value) <= 0 || $value[0] == '\\') {
             $value = ltrim($value, '\\');
 
             return;

--- a/test/Generator/FileGeneratorTest.php
+++ b/test/Generator/FileGeneratorTest.php
@@ -184,7 +184,7 @@ EOS;
 
         $targetLength = strlen('require_once \'SampleClass.php\';');
         self::assertEquals($targetLength, strlen($lines[2]));
-        self::assertEquals(';', $lines[2]{$targetLength - 1});
+        self::assertEquals(';', $lines[2][$targetLength - 1]);
     }
 
     /**


### PR DESCRIPTION
As of PHP 7.4:
the array and string offset access syntax using curly braces is deprecated.