### PR TITLE
fix Trying to access array offset on value of type nul (7.4)

### DIFF
--- a/src/Scanner/MethodScanner.php
+++ b/src/Scanner/MethodScanner.php
@@ -452,7 +452,7 @@ class MethodScanner implements ScannerInterface
                 $tokenType    = null;
                 $tokenContent = $token;
                 $tokenLine    = $tokenLine + substr_count(
-                    $lastTokenArray[1],
+                    $lastTokenArray[1] ?? null,
                     "\n"
                 ); // adjust token line by last known newline count
             } else {


### PR DESCRIPTION
With 7.4.0beta4

```
There were 16 errors:

1) ZendTest\Code\Scanner\ClassScannerTest::testClassScannerHasClassInformation
Trying to access array offset on value of type null

/work/GIT/zend/zend-code/src/Scanner/MethodScanner.php:455
/work/GIT/zend/zend-code/src/Scanner/MethodScanner.php:592
/work/GIT/zend/zend-code/src/Scanner/MethodScanner.php:155
/work/GIT/zend/zend-code/src/Scanner/ClassScanner.php:712
/work/GIT/zend/zend-code/test/Scanner/ClassScannerTest.php:65

2) ZendTest\Code\Scanner\ClassScannerTest::testClassScannerHasMethods
Trying to access array offset on value of type null

/work/GIT/zend/zend-code/src/Scanner/MethodScanner.php:455
/work/GIT/zend/zend-code/src/Scanner/MethodScanner.php:592
/work/GIT/zend/zend-code/src/Scanner/MethodScanner.php:155
/work/GIT/zend/zend-code/src/Scanner/ClassScanner.php:712
/work/GIT/zend/zend-code/test/Scanner/ClassScannerTest.php:89

3) ZendTest\Code\Scanner\ClassScannerTest::testHasMethod
Trying to access array offset on value of type null

/work/GIT/zend/zend-code/src/Scanner/MethodScanner.php:455
/work/GIT/zend/zend-code/src/Scanner/MethodScanner.php:592
/work/GIT/zend/zend-code/src/Scanner/MethodScanner.php:155
/work/GIT/zend/zend-code/src/Scanner/ClassScanner.php:827
/work/GIT/zend/zend-code/src/Scanner/ClassScanner.php:846
/work/GIT/zend/zend-code/test/Scanner/ClassScannerTest.php:139

4) ZendTest\Code\Scanner\ClassScannerTest::testClassScannerCanScanTraits
Trying to access array offset on value of type null

/work/GIT/zend/zend-code/src/Scanner/MethodScanner.php:455
/work/GIT/zend/zend-code/src/Scanner/MethodScanner.php:592
/work/GIT/zend/zend-code/src/Scanner/MethodScanner.php:155
/work/GIT/zend/zend-code/src/Scanner/ClassScanner.php:827
/work/GIT/zend/zend-code/src/Scanner/ClassScanner.php:846
/work/GIT/zend/zend-code/test/Scanner/ClassScannerTest.php:207

5) ZendTest\Code\Scanner\ClassScannerTest::testClassScannerCanGetTraitMethodsInGetMethods
Trying to access array offset on value of type null

/work/GIT/zend/zend-code/src/Scanner/MethodScanner.php:455
/work/GIT/zend/zend-code/src/Scanner/MethodScanner.php:592
/work/GIT/zend/zend-code/src/Scanner/MethodScanner.php:155
/work/GIT/zend/zend-code/src/Scanner/ClassScanner.php:746
/work/GIT/zend/zend-code/src/Scanner/ClassScanner.php:709
/work/GIT/zend/zend-code/test/Scanner/ClassScannerTest.php:267

6) ZendTest\Code\Scanner\ClassScannerTest::testGetMethodsThrowsExceptionOnDuplicateMethods
Trying to access array offset on value of type null

/work/GIT/zend/zend-code/src/Scanner/MethodScanner.php:455
/work/GIT/zend/zend-code/src/Scanner/MethodScanner.php:592
/work/GIT/zend/zend-code/src/Scanner/MethodScanner.php:155
/work/GIT/zend/zend-code/src/Scanner/ClassScanner.php:746
/work/GIT/zend/zend-code/test/Scanner/ClassScannerTest.php:293

7) ZendTest\Code\Scanner\MethodScannerTest::testMethodScannerHasMethodInformation
Trying to access array offset on value of type null

/work/GIT/zend/zend-code/src/Scanner/MethodScanner.php:455
/work/GIT/zend/zend-code/src/Scanner/MethodScanner.php:592
/work/GIT/zend/zend-code/src/Scanner/MethodScanner.php:155
/work/GIT/zend/zend-code/src/Scanner/ClassScanner.php:827
/work/GIT/zend/zend-code/test/Scanner/MethodScannerTest.php:26

8) ZendTest\Code\Scanner\MethodScannerTest::testMethodScannerReturnsParameters
Trying to access array offset on value of type null

/work/GIT/zend/zend-code/src/Scanner/MethodScanner.php:455
/work/GIT/zend/zend-code/src/Scanner/MethodScanner.php:592
/work/GIT/zend/zend-code/src/Scanner/MethodScanner.php:155
/work/GIT/zend/zend-code/src/Scanner/ClassScanner.php:827
/work/GIT/zend/zend-code/test/Scanner/MethodScannerTest.php:40

9) ZendTest\Code\Scanner\MethodScannerTest::testMethodScannerReturnsParameterScanner
Trying to access array offset on value of type null

/work/GIT/zend/zend-code/src/Scanner/MethodScanner.php:455
/work/GIT/zend/zend-code/src/Scanner/MethodScanner.php:592
/work/GIT/zend/zend-code/src/Scanner/MethodScanner.php:155
/work/GIT/zend/zend-code/src/Scanner/ClassScanner.php:827
/work/GIT/zend/zend-code/test/Scanner/MethodScannerTest.php:49

10) ZendTest\Code\Scanner\MethodScannerTest::testMethodScannerParsesClassNames
Trying to access array offset on value of type null

/work/GIT/zend/zend-code/src/Scanner/MethodScanner.php:455
/work/GIT/zend/zend-code/src/Scanner/MethodScanner.php:592
/work/GIT/zend/zend-code/src/Scanner/MethodScanner.php:155
/work/GIT/zend/zend-code/src/Scanner/ClassScanner.php:827
/work/GIT/zend/zend-code/test/Scanner/MethodScannerTest.php:60

11) ZendTest\Code\Scanner\MethodScannerTest::testMethodScannerReturnsPropertyWithNoDefault
Trying to access array offset on value of type null

/work/GIT/zend/zend-code/src/Scanner/MethodScanner.php:455
/work/GIT/zend/zend-code/src/Scanner/MethodScanner.php:592
/work/GIT/zend/zend-code/src/Scanner/MethodScanner.php:155
/work/GIT/zend/zend-code/src/Scanner/ClassScanner.php:827
/work/GIT/zend/zend-code/test/Scanner/MethodScannerTest.php:70

12) ZendTest\Code\Scanner\MethodScannerTest::testMethodScannerReturnsLineNumbersForMethods
Trying to access array offset on value of type null

/work/GIT/zend/zend-code/src/Scanner/MethodScanner.php:455
/work/GIT/zend/zend-code/src/Scanner/MethodScanner.php:592
/work/GIT/zend/zend-code/src/Scanner/MethodScanner.php:155
/work/GIT/zend/zend-code/src/Scanner/ClassScanner.php:827
/work/GIT/zend/zend-code/test/Scanner/MethodScannerTest.php:78

13) ZendTest\Code\Scanner\MethodScannerTest::testMethodScannerReturnsBodyMethods
Trying to access array offset on value of type null

/work/GIT/zend/zend-code/src/Scanner/MethodScanner.php:455
/work/GIT/zend/zend-code/src/Scanner/MethodScanner.php:592
/work/GIT/zend/zend-code/src/Scanner/MethodScanner.php:155
/work/GIT/zend/zend-code/src/Scanner/ClassScanner.php:827
/work/GIT/zend/zend-code/test/Scanner/MethodScannerTest.php:87

14) ZendTest\Code\Scanner\MethodScannerTest::testMethodScannerMethodSignatureLatestOptionalParamHasParentheses
Trying to access array offset on value of type null

/work/GIT/zend/zend-code/src/Scanner/MethodScanner.php:455
/work/GIT/zend/zend-code/src/Scanner/MethodScanner.php:592
/work/GIT/zend/zend-code/src/Scanner/MethodScanner.php:155
/work/GIT/zend/zend-code/src/Scanner/ClassScanner.php:827
/work/GIT/zend/zend-code/test/Scanner/MethodScannerTest.php:96

15) ZendTest\Code\Scanner\MethodScannerTest::testMethodScannerWorksWithSingleAbstractFunction
Trying to access array offset on value of type null

/work/GIT/zend/zend-code/src/Scanner/MethodScanner.php:455
/work/GIT/zend/zend-code/src/Scanner/MethodScanner.php:592
/work/GIT/zend/zend-code/src/Scanner/MethodScanner.php:155
/work/GIT/zend/zend-code/src/Scanner/ClassScanner.php:827
/work/GIT/zend/zend-code/test/Scanner/MethodScannerTest.php:110

16) ZendTest\Code\Scanner\ParameterScannerTest::testParameterScannerHasParameterInformation
Trying to access array offset on value of type null

/work/GIT/zend/zend-code/src/Scanner/MethodScanner.php:455
/work/GIT/zend/zend-code/src/Scanner/MethodScanner.php:592
/work/GIT/zend/zend-code/src/Scanner/MethodScanner.php:155
/work/GIT/zend/zend-code/src/Scanner/ClassScanner.php:827
/work/GIT/zend/zend-code/test/Scanner/ParameterScannerTest.php:22

ERRORS!
Tests: 996, Assertions: 1557, Errors: 16, Skipped: 9, Incomplete: 4.

```