### PR TITLE
Fix return type of FileGenerator::getClass

### DIFF
--- a/src/Generator/FileGenerator.php
+++ b/src/Generator/FileGenerator.php
@@ -337,7 +337,7 @@ class FileGenerator extends AbstractGenerator
 
     /**
      * @param  string $name
-     * @return ClassGenerator
+     * @return ClassGenerator|false
      */
     public function getClass($name = null)
     {


### PR DESCRIPTION
Provide a narrative description of what you are trying to accomplish:

- [Y ] Is this related to quality assurance?
Return type of `\Zend\Code\Generator\FileGenerator::getClass` only has `ClassGenerator` while it can also return false when the classes array is empty.
PHPStan will whine about this, because it should always return a true-thy return, also it gives the perception it will always return the ClassGenerator (while it doesn't always do that)

Therefor I added the false to the return type in the docblock.
