### PR TITLE
Fix exception message in ValueGenerator for invalid values

### DIFF
--- a/src/Generator/ValueGenerator.php
+++ b/src/Generator/ValueGenerator.php
@@ -437,9 +437,10 @@ class ValueGenerator extends AbstractGenerator
                 break;
             case self::TYPE_OTHER:
             default:
-                throw new Exception\RuntimeException(
-                    sprintf('Type "%s" is unknown or cannot be used as property default value.', get_class($value))
-                );
+                throw new Exception\RuntimeException(sprintf(
+                    'Type "%s" is unknown or cannot be used as property default value.',
+                    is_object($value) ? get_class($value) : gettype($value)
+                ));
         }
 
         return $output;

--- a/test/Generator/ValueGeneratorTest.php
+++ b/test/Generator/ValueGeneratorTest.php
@@ -11,8 +11,11 @@ namespace ZendTest\Code\Generator;
 
 use ArrayAccess;
 use ArrayObject as SplArrayObject;
+use DateTime;
+use Generator;
 use PHPUnit\Framework\TestCase;
 use Zend\Code\Exception\InvalidArgumentException;
+use Zend\Code\Exception\RuntimeException;
 use Zend\Code\Generator\PropertyGenerator;
 use Zend\Code\Generator\PropertyValueGenerator;
 use Zend\Code\Generator\ValueGenerator;
@@ -461,5 +464,25 @@ EOS;
             ["'", "\\'"],
             ["\\'", "\\\\\\'"],
         ];
+    }
+
+    public function invalidValue() : Generator
+    {
+        yield 'object' => [new DateTime(), DateTime::class];
+        yield 'resource' => [fopen('php://input', 'r'), 'resource'];
+    }
+
+    /**
+     * @dataProvider invalidValue
+     *
+     * @param mixed $value
+     */
+    public function testExceptionInvalidValue($value, string $type) : void
+    {
+        $valueGenerator = new ValueGenerator($value);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Type "'.$type.'" is unknown or cannot be used');
+        $valueGenerator->generate();
     }
 }


### PR DESCRIPTION
When resource provided we should throw exception that this type
cannot be used, but we tried to get_class on resource, what is invalid.

- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
  - [x] Detail the original, incorrect behavior.
  - [x] Detail the new, expected behavior.
  - [x] Base your feature on the `master` branch, and submit against that branch.
  - [x] Add a regression test that demonstrates the bug, and proves the fix.
  - [ ] Add a `CHANGELOG.md` entry for the fix.

Fixes #178 